### PR TITLE
Change required PHP version from 5.3.10 to 5.3.1 (typo?)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/joomla/joomla-framework",
     "license": "GPL-2.0+",
     "require": {
-        "php": ">=5.3.10"
+        "php": ">=5.3.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
I suspect this is a typo in composer.json?
