### PR TITLE
Fix PHPUnit test that fails on Windows

### DIFF
--- a/vendor/Joomla/Database/Query.php
+++ b/vendor/Joomla/Database/Query.php
@@ -1247,7 +1247,7 @@ abstract class Query
 		if (is_null($this->set))
 		{
 			$glue = strtoupper($glue);
-			$this->set = new Query\Element('SET', $conditions, "\n\t$glue ");
+			$this->set = new Query\Element('SET', $conditions, PHP_EOL . "\t$glue ");
 		}
 		else
 		{


### PR DESCRIPTION
The assertion "Test appending with set()" in
vendor/Joomla/Database/Tests/QueryTest.php:1362 fails, because it's using
PHP_EOL in the test, and \n in the implementation. On Windows, PHP_EOL is
set to \r\n and so the test passes on Travis CI, but fails on Windows.
- Change implementation, use PHP_EOL instead of \n
