### PR TITLE
Decouple Registry from the Cache package

### DIFF
--- a/vendor/Joomla/Cache/Apc.php
+++ b/vendor/Joomla/Cache/Apc.php
@@ -125,7 +125,7 @@ class Apc extends Cache
 	 */
 	public function set($key, $value, $ttl = null)
 	{
-		return apc_store($key, $value, $ttl ?: $this->options->get('ttl'));
+		return apc_store($key, $value, $ttl ?: $this->options['ttl']);
 	}
 
 	/**

--- a/vendor/Joomla/Cache/Cache.php
+++ b/vendor/Joomla/Cache/Cache.php
@@ -18,7 +18,7 @@ use Psr\Cache\CacheItemInterface;
 abstract class Cache implements CacheInterface
 {
 	/**
-	 * @var    Registry  The options for the cache object.
+	 * @var    ArrayAccess  The options for the cache object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -31,12 +31,18 @@ abstract class Cache implements CacheInterface
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct(Registry $options = null)
+	public function __construct(\ArrayAccess $options = null)
 	{
 		// Set the options object.
-		$this->options = $options ? $options : new Registry;
-
-		$this->options->def('ttl', 900);
+		if ($options instanceof \ArrayAccess)
+		{
+			$this->options = $options;
+		}
+		else
+		{
+			$this->options = new \ArrayObject;
+			$this->options['ttl'] = 900;
+		}
 	}
 
 	/**
@@ -92,7 +98,7 @@ abstract class Cache implements CacheInterface
 	 */
 	public function getOption($key)
 	{
-		return $this->options->get($key);
+		return $this->options[$key];
 	}
 
 	/**
@@ -175,7 +181,7 @@ abstract class Cache implements CacheInterface
 	 */
 	public function setOption($key, $value)
 	{
-		$this->options->set($key, $value);
+		$this->options[$key] = $value;
 
 		return $this;
 	}

--- a/vendor/Joomla/Cache/File.php
+++ b/vendor/Joomla/Cache/File.php
@@ -33,8 +33,12 @@ class File extends Cache
 	{
 		parent::__construct($options);
 
-		$this->options->def('file.locking', true);
-		$this->checkFilePath($this->options->get('file.path'));
+		if (!isset($this->options['file.locking']))
+		{
+			$this->options['file.locking'] = true;
+		}
+
+		$this->checkFilePath($this->options['file.path']);
 	}
 
 	/**
@@ -46,7 +50,7 @@ class File extends Cache
 	 */
 	public function clear()
 	{
-		$filePath = $this->options->get('file.path');
+		$filePath = $this->options['file.path'];
 		$this->checkFilePath($filePath);
 
 		$iterator = new \RegexIterator(
@@ -72,7 +76,7 @@ class File extends Cache
 	 *
 	 * @param   string  $key  The storage entry identifier.
 	 *
-	 * @return  mixed
+	 * @return  CacheItemInterface
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
@@ -107,7 +111,7 @@ class File extends Cache
 		}
 
 		// If locking is enabled get a shared lock for reading on the resource.
-		if ($this->options->get('file.locking') && !flock($resource, LOCK_SH))
+		if ($this->options['file.locking'] && !flock($resource, LOCK_SH))
 		{
 			throw new \RuntimeException(sprintf('Unable to fetch cache entry for %s.  Connot obtain a lock.', $key));
 		}
@@ -115,7 +119,7 @@ class File extends Cache
 		$data = stream_get_contents($resource);
 
 		// If locking is enabled release the lock on the resource.
-		if ($this->options->get('file.locking') && !flock($resource, LOCK_UN))
+		if ($this->options['file.locking'] && !flock($resource, LOCK_UN))
 		{
 			throw new \RuntimeException(sprintf('Unable to fetch cache entry for %s.  Connot release the lock.', $key));
 		}
@@ -166,7 +170,7 @@ class File extends Cache
 		$success = (bool) file_put_contents(
 			$fileName,
 			serialize($value),
-			($this->options->get('file.locking') ? LOCK_EX : null)
+			($this->options['file.locking'] ? LOCK_EX : null)
 		);
 
 		return $success;
@@ -222,7 +226,7 @@ class File extends Cache
 	 */
 	private function fetchStreamUri($key)
 	{
-		$filePath = $this->options->get('file.path');
+		$filePath = $this->options['file.path'];
 		$this->checkFilePath($filePath);
 
 		return sprintf(
@@ -245,7 +249,7 @@ class File extends Cache
 	private function isExpired($key)
 	{
 		// Check to see if the cached data has expired.
-		if (filemtime($this->fetchStreamUri($key)) < (time() - $this->options->get('ttl')))
+		if (filemtime($this->fetchStreamUri($key)) < (time() - $this->options['ttl']))
 		{
 			return true;
 		}

--- a/vendor/Joomla/Cache/Memcached.php
+++ b/vendor/Joomla/Cache/Memcached.php
@@ -154,7 +154,7 @@ class Memcached extends Cache
 			return;
 		}
 
-		$pool = $this->options->get('memcache.pool');
+		$pool = $this->options['memcache.pool'];
 
 		if ($pool)
 		{
@@ -165,14 +165,14 @@ class Memcached extends Cache
 			$this->driver = new \Memcached;
 		}
 
-		$this->driver->setOption(\Memcached::OPT_COMPRESSION, $this->options->get('memcache.compress', false));
+		$this->driver->setOption(\Memcached::OPT_COMPRESSION, $this->options['memcache.compress'] ?: false);
 		$this->driver->setOption(\Memcached::OPT_LIBKETAMA_COMPATIBLE, true);
 		$serverList = $this->driver->getServerList();
 
 		// If we are using a persistent pool we don't want to add the servers again.
 		if (empty($serverList))
 		{
-			$servers = $this->options->get('memcache.servers', array());
+			$servers = $this->options['memcache.servers'] ?: array();
 
 			foreach ($servers as $server)
 			{

--- a/vendor/Joomla/Cache/README.md
+++ b/vendor/Joomla/Cache/README.md
@@ -59,18 +59,19 @@ The **File** cache allows the following additional options:
 * file.path - the path where the cache files are to be stored.
 * file.locking
 
-```
+```php
 use Joomla\Cache;
 
-$options = new Registry;
-$options->set('file.path', __DIR__ . '/cache');
+$options = array(
+	'file.path' => __DIR__ . '/cache',
+);
 
 $cache = new Cache\File($options);
 ```
 
 ### Memcached
 
-```
+```php
 use Joomla\Cache;
 
 $cache = new Cache\Memcached;
@@ -78,7 +79,7 @@ $cache = new Cache\Memcached;
 
 ### None
 
-```
+```php
 use Joomla\Cache;
 
 $cache = new Cache\None;
@@ -86,7 +87,7 @@ $cache = new Cache\None;
 
 ### Runtime
 
-```
+```php
 use Joomla\Cache;
 
 $cache = new Cache\Runtime;
@@ -94,7 +95,7 @@ $cache = new Cache\Runtime;
 
 ### Wincache
 
-```
+```php
 use Joomla\Cache;
 
 $cache = new Cache\Wincache;
@@ -102,8 +103,75 @@ $cache = new Cache\Wincache;
 
 ### XCache
 
-```
+```php
 use Joomla\Cache;
 
 $cache = new Cache\XCache;
 ```
+
+## Test Mocking
+
+The `Cache` package provide a **PHPUnit** helper to mock a `Cache\Cache` object or an `Cache\Item` object. You can include your own optional overrides in the test class for the following methods:
+
+* `Cache\Cache::get`: Add a method called `mockCacheGet` to your test class. If omitted, the helper will return a default mock for the `Cache\Item` class.
+* `Cache\Item::getValue`: Add a method called `mockCacheItemGetValue` to your test class. If omitted, the mock `Cache\Item` will return `"value"` when this method is called.
+* `Cache\Item::isHit`: Add a method called `mockCacheItemIsHit` to your test class. If omitted, the mock `Cache\Item` will return `false` when this method is called.
+
+```php
+use Joomla\Cache\Tests\Mocker as CacheMocker;
+
+class FactoryTest extends \PHPUnit_Framework_TestCase
+{
+	private $instance;
+	
+	//
+	// The following mocking methods are optional.
+	//
+
+	/**
+	 * Callback to mock the Cache\Item::getValue method.
+	 *
+	 * @return  string
+	 */
+	public function mockCacheItemGetValue()
+	{
+		// This is the default handling.
+		// You can override this method to provide a custom return value.
+		return 'value';
+	}
+
+	/**
+	 * Callback to mock the Cache\Item::isHit method.
+	 *
+	 * @return  boolean
+	 */
+	public function mockCacheItemIsHit()
+	{
+		// This is the default handling.
+		// You can override this method to provide a custom return value.
+		return false;
+	}
+
+	/**
+	 * Callback to mock the Cache\Cache::get method.
+	 *
+	 * @param   string  $text  The input text.
+	 *
+	 * @return  string
+	 */
+	public function mockCacheGet($key)
+	{
+		// This is the default handling.
+		// You can override this method to provide a custom return value.
+		return $this->createMockItem();
+	}
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$mocker = new CacheMocker($this);
+
+		$this->instance = new SomeClass($mocker->createMockCache());
+	}
+}

--- a/vendor/Joomla/Cache/README.md
+++ b/vendor/Joomla/Cache/README.md
@@ -4,15 +4,16 @@ This cache package complies with the `Psr\Cache` standard.
 
 ## Options and General Usage
 
-Each of the cache storage types supports the following options:
+Following option as available across a cache storage types:
 
 * ttl - Time to live.
 
 ```
 use Joomla\Cache;
 
-$options = new Registry;
-$options->set('ttl', 900);
+$options = array(
+	'ttl' => 900,
+);
 
 $cache = new Cache\Runtime($options);
 

--- a/vendor/Joomla/Cache/Tests/Mocker.php
+++ b/vendor/Joomla/Cache/Tests/Mocker.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Cache\Tests;
+
+use Joomla\Test\Helper;
+
+/**
+ * Class to mock Joomla\Mocker\Cache.
+ *
+ * @since  1.0
+ */
+class Mocker
+{
+	/**
+	 * @var    \PHPUnit_Framework_TestCase
+	 * @since  1.0
+	 */
+	private $test;
+
+	/**
+	 * Class contructor.
+	 *
+	 * @param  \PHPUnit_Framework_TestCase  $test  A test class.
+	 */
+	public function __construct(\PHPUnit_Framework_TestCase $test)
+	{
+		$this->test = $test;
+	}
+
+	/**
+	 * Creates and instance of a mock Joomla\Mocker\Cache object.
+	 *
+	 * @return  object
+	 *
+	 * @since   1.0
+	 */
+	public function createMockCache()
+	{
+		// Collect all the relevant methods in JDatabase.
+		$methods = array(
+			'clear',
+			'exists',
+			'get',
+			'getMultiple',
+			'remove',
+			'removeMultiple',
+			'set',
+			'setMultiple',
+		);
+
+		// Create the mock.
+		$mockObject = $this->test->getMock(
+			'Joomla\Cache\Cache',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			false
+		);
+
+		Helper::assignMockCallbacks(
+			$mockObject,
+			$this->test,
+			array(
+				'get' => array((is_callable(array($this->test, 'mockCacheGet')) ? $this->test : $this), 'mockCacheGet'),
+			)
+		);
+
+		return $mockObject;
+	}
+
+	/**
+	 * Creates and instance of a mock Joomla\Cache\Item object.
+	 *
+	 * @return  object
+	 *
+	 * @since   1.0
+	 */
+	public function createMockItem()
+	{
+		// Collect all the relevant methods in JDatabase.
+		$methods = array(
+			'getKey',
+			'getValue',
+			'isHit',
+			'setValue',
+		);
+
+		// Create the mock.
+		$mockObject = $this->test->getMock(
+			'Joomla\Cache\Item',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			false
+		);
+
+		Helper::assignMockCallbacks(
+			$mockObject,
+			$this->test,
+			array(
+				'getValue' => array((is_callable(array($this->test, 'mockCacheItemGetValue')) ? $this->test : $this), 'mockCacheItemGetValue'),
+				'isHit' => array((is_callable(array($this->test, 'mockCacheItemIsHit')) ? $this->test : $this), 'mockCacheItemIsHit'),
+			)
+		);
+
+		return $mockObject;
+	}
+
+	/**
+	 * Callback to mock the Joomla\Cache\Cache::get method.
+	 *
+	 * @param   string  $text  The input text.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function mockCacheGet($key)
+	{
+		return $this->createMockItem();
+	}
+
+	/**
+	 * Callback to mock the Joomla\Cache\Item::getValue method.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function mockCacheItemGetValue()
+	{
+		return 'value';
+	}
+
+	/**
+	 * Callback to mock the Joomla\Cache\Item::isHit method.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   1.0
+	 */
+	public function mockCacheItemIsHit()
+	{
+		return false;
+	}
+}

--- a/vendor/Joomla/Cache/composer.json
+++ b/vendor/Joomla/Cache/composer.json
@@ -6,8 +6,13 @@
     "homepage": "https://github.com/joomla/joomla-framework-cache",
     "license": "GPL-2.0+",
     "require": {
-        "php": ">=5.3.10",
-        "joomla/registry": "dev-master"
+        "php": ">=5.3.10"
+    },
+    "require-dev": {
+         "joomla/test": "dev-master"
+    },
+    "suggest": {
+        "joomla/registry": "Registry can be used as an alternative to using an array for the caching options."
     },
     "target-dir": "Joomla/Cache",
     "autoload": {

--- a/vendor/Joomla/Registry/README.md
+++ b/vendor/Joomla/Registry/README.md
@@ -1,1 +1,36 @@
 # The Registry Package
+
+```
+use Joomla\Registry\Registry;
+
+$registry = new Registry;
+
+// Set a value in the registry.
+$registry->set('foo') = 'bar';
+
+// Get a value from the registry;
+$value = $registry->get('foo');
+
+```
+
+## Accessing a Registry as an Array
+
+The `Registry` class implements `ArrayAccess` so the properties of the registry can be accessed as an array. Consider the following examples:
+
+```
+use Joomla\Registry\Registry;
+
+$registry = new Registry;
+
+// Set a value in the registry.
+$registry['foo'] = 'bar';
+
+// Get a value from the registry;
+$value = $registry['foo'];
+
+// Check if a key in the registry is set.
+if (isset($registry['foo']))
+{
+	echo 'Say bar.';
+}
+```

--- a/vendor/Joomla/Registry/Registry.php
+++ b/vendor/Joomla/Registry/Registry.php
@@ -13,7 +13,7 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.0
  */
-class Registry implements \JsonSerializable
+class Registry implements \JsonSerializable, \ArrayAccess
 {
 	/**
 	 * Registry Object
@@ -321,6 +321,63 @@ class Registry implements \JsonSerializable
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks whether an offset exists in the iterator.
+	 *
+	 * @param   mixed  $offset  The array offset.
+	 *
+	 * @return  boolean  True if the offset exists, false otherwise.
+	 *
+	 * @since   1.0
+	 */
+	public function offsetExists($offset)
+	{
+		return (boolean) ($this->get($offset) !== null);
+	}
+
+	/**
+	 * Gets an offset in the iterator.
+	 *
+	 * @param   mixed  $offset  The array offset.
+	 *
+	 * @return  mixed  The array value if it exists, null otherwise.
+	 *
+	 * @since   1.0
+	 */
+	public function offsetGet($offset)
+	{
+		return $this->get($offset);
+	}
+
+	/**
+	 * Sets an offset in the iterator.
+	 *
+	 * @param   mixed  $offset  The array offset.
+	 * @param   mixed  $value   The array value.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function offsetSet($offset, $value)
+	{
+		$this->set($offset, $value);
+	}
+
+	/**
+	 * Unsets an offset in the iterator.
+	 *
+	 * @param   mixed  $offset  The array offset.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function offsetUnset($offset)
+	{
+		$this->set($offset, null);
 	}
 
 	/**

--- a/vendor/Joomla/Registry/Tests/RegistryTest.php
+++ b/vendor/Joomla/Registry/Tests/RegistryTest.php
@@ -15,7 +15,7 @@ use Joomla\Test\Helper;
 class RegistryTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * Test the Registry::__clone method.
+	 * Test the Joomla\Registry\Registry::__clone method.
 	 *
 	 * @return  void
 	 *
@@ -41,7 +41,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::__toString method.
+	 * Test the Joomla\Registry\Registry::__toString method.
 	 *
 	 * @return  void
 	 *
@@ -63,7 +63,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::jsonSerialize method.
+	 * Test the Joomla\Registry\Registry::jsonSerialize method.
 	 *
 	 * @return  void
 	 *
@@ -113,7 +113,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::def method.
+	 * Test the Joomla\Registry\Registry::def method.
 	 *
 	 * @return  void
 	 *
@@ -138,7 +138,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tet the Registry::bindData method.
+	 * Tet the Joomla\Registry\Registry::bindData method.
 	 *
 	 * @return  void
 	 *
@@ -180,7 +180,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::exists method.
+	 * Test the Joomla\Registry\Registry::exists method.
 	 *
 	 * @return  void
 	 *
@@ -226,7 +226,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::get method
+	 * Test the Joomla\Registry\Registry::get method
 	 *
 	 * @return  void
 	 *
@@ -242,7 +242,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::getInstance method.
+	 * Test the Joomla\Registry\Registry::getInstance method.
 	 *
 	 * @return  void
 	 *
@@ -279,7 +279,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::loadArray method.
+	 * Test the Joomla\Registry\Registry::loadArray method.
 	 *
 	 * @return  void
 	 *
@@ -305,7 +305,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::loadFile method.
+	 * Test the Joomla\Registry\Registry::loadFile method.
 	 *
 	 * @return  void
 	 *
@@ -352,7 +352,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::loadString() method.
+	 * Test the Joomla\Registry\Registry::loadString() method.
 	 *
 	 * @return  void
 	 *
@@ -405,7 +405,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::loadObject method.
+	 * Test the Joomla\Registry\Registry::loadObject method.
 	 *
 	 * @return  void
 	 *
@@ -439,7 +439,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::merge method.
+	 * Test the Joomla\Registry\Registry::merge method.
 	 *
 	 * @return  void
 	 *
@@ -502,7 +502,77 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::set method.
+	 * Test the Joomla\Registry\Registry::offsetExists method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Registry\Registry::offsetExists
+	 * @since   1.0
+	 */
+	public function testOffsetExists()
+	{
+		$instance = new Registry;
+
+		$this->assertTrue(empty($instance['foo.bar']));
+
+		$instance->set('foo.bar', 'value');
+
+		$this->assertTrue(isset($instance['foo.bar']), 'Checks a known offset by isset.');
+		$this->assertFalse(isset($instance['goo.car']), 'Checks an uknown offset.');
+	}
+
+	/**
+	 * Test the Joomla\Registry\Registry::offsetGet method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Registry\Registry::offsetGet
+	 * @since   1.0
+	 */
+	public function testOffsetGet()
+	{
+		$instance = new Registry;
+		$instance->set('foo.bar', 'value');
+
+		$this->assertEquals('value', $instance['foo.bar'], 'Checks a known offset.');
+		$this->assertNull($instance['goo.car'], 'Checks a unknown offset.');
+	}
+
+	/**
+	 * Test the Joomla\Registry\Registry::offsetSet method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Registry\Registry::offsetSet
+	 * @since   1.0
+	 */
+	public function testOffsetSet()
+	{
+		$instance = new Registry;
+
+		$instance['foo.bar'] = 'value';
+		$this->assertEquals('value', $instance->get('foo.bar'), 'Checks the set.');
+	}
+
+	/**
+	 * Test the Joomla\Registry\Registry::offsetUnset method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Registry\Registry::offsetUnset
+	 * @since   1.0
+	 */
+	public function testOffsetUnset()
+	{
+		$instance = new Registry;
+		$instance->set('foo.bar', 'value');
+
+		unset($instance['foo.bar']);
+		$this->assertFalse(isset($instance['foo.bar']));
+	}
+
+	/**
+	 * Test the Joomla\Registry\Registry::set method.
 	 *
 	 * @return  void
 	 *
@@ -522,7 +592,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::toArray method.
+	 * Test the Joomla\Registry\Registry::toArray method.
 	 *
 	 * @return  void
 	 *
@@ -550,7 +620,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::toObject method.
+	 * Test the Joomla\Registry\Registry::toObject method.
 	 *
 	 * @return  void
 	 *
@@ -578,7 +648,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Registry::toString method.
+	 * Test the Joomla\Registry\Registry::toString method.
 	 *
 	 * @return  void
 	 *

--- a/vendor/Joomla/Registry/composer.json
+++ b/vendor/Joomla/Registry/composer.json
@@ -10,6 +10,9 @@
          "joomla/compat": "dev-master",
          "joomla/utilities": "dev-master"
     },
+    "require-dev": {
+         "joomla/test": "dev-master"
+    },
     "target-dir": "Joomla/Registry",
     "autoload": {
     	"psr-0": {


### PR DESCRIPTION
Registry now implements ArrayAccess.
Cache class options have been changed to use an object that implements ArrayAccess (or just a plain array).
Added a mocking helper to generate mock classes for Cache\Cache and Cache\Item.
