### PR TITLE
Updating Cache constructor to accept array() or \ArrayAccess

### DIFF
--- a/vendor/Joomla/Cache/Apc.php
+++ b/vendor/Joomla/Cache/Apc.php
@@ -19,12 +19,12 @@ class Apc extends Cache
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry  $options  Caching options object.
+	 * @param   mixed  $options  An options array, or an object that implements \ArrayAccess
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct(Registry $options = null)
+	public function __construct($options = null)
 	{
 		parent::__construct($options);
 

--- a/vendor/Joomla/Cache/Cache.php
+++ b/vendor/Joomla/Cache/Cache.php
@@ -26,22 +26,26 @@ abstract class Cache implements CacheInterface
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry  $options  Caching options object.
+	 * @param   mixed  $options  An options array, or an object that implements \ArrayAccess
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct(\ArrayAccess $options = null)
+	public function __construct($options = array())
 	{
-		// Set the options object.
-		if ($options instanceof \ArrayAccess)
+		if ($options instanceof \ArrayAccess || is_array($options))
 		{
+			// Set a default ttl if none is set in the options.
+			if (!isset($options['ttl']))
+			{
+				$options['ttl'] = 900;
+			}
+
 			$this->options = $options;
 		}
 		else
 		{
-			$this->options = new \ArrayObject;
-			$this->options['ttl'] = 900;
+			throw new \RuntimeException(sprintf('%s requires an options array or an object that implements \\ArrayAccess', __CLASS__));
 		}
 	}
 

--- a/vendor/Joomla/Cache/File.php
+++ b/vendor/Joomla/Cache/File.php
@@ -24,12 +24,12 @@ class File extends Cache
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry  $options  Caching options object.
+	 * @param   mixed  $options  An options array, or an object that implements \ArrayAccess
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct(Registry $options = null)
+	public function __construct($options = null)
 	{
 		parent::__construct($options);
 

--- a/vendor/Joomla/Cache/Memcached.php
+++ b/vendor/Joomla/Cache/Memcached.php
@@ -25,12 +25,12 @@ class Memcached extends Cache
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry  $options  Caching options object.
+	 * @param   mixed  $options  An options array, or an object that implements \ArrayAccess
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct(Registry $options = null)
+	public function __construct($options = null)
 	{
 		parent::__construct($options);
 

--- a/vendor/Joomla/Cache/Wincache.php
+++ b/vendor/Joomla/Cache/Wincache.php
@@ -24,7 +24,7 @@ class Wincache extends Cache
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct(Registry $options = null)
+	public function __construct($options = null)
 	{
 		parent::__construct($options);
 

--- a/vendor/Joomla/Cache/XCache.php
+++ b/vendor/Joomla/Cache/XCache.php
@@ -24,7 +24,7 @@ class XCache extends Cache
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct(Registry $options = null)
+	public function __construct($options = null)
 	{
 		parent::__construct($options);
 


### PR DESCRIPTION
This refines the cache package to allow an `$options` array to be passed, or an object that implements `\ArrayAccess`. It removes the typehint, so that regular arrays can be used as well.
