### PR TITLE
Refactor Archive to be OO and add Documentation

### DIFF
--- a/vendor/Joomla/Archive/Archive.php
+++ b/vendor/Joomla/Archive/Archive.php
@@ -42,7 +42,7 @@ class Archive implements LoggerAwareInterface
 	 * @var    mixed  Array or object that implements \ArrayAccess
 	 * @since  1.0
 	 */
-	protected $options = array();
+	public $options = array();
 
 	/**
 	 * Create a new Archive object.
@@ -73,6 +73,7 @@ class Archive implements LoggerAwareInterface
 		$result = false;
 		$ext = pathinfo($archivename, PATHINFO_EXTENSION);
 		$filename = pathinfo($archivename, PATHINFO_FILENAME);
+		$path = pathinfo($archivename, PATHINFO_DIRNAME);
 
 		switch ($ext)
 		{
@@ -105,7 +106,7 @@ class Archive implements LoggerAwareInterface
 				else
 				{
 					Folder::create($path);
-					$result = File::copy($tmpfname, $path . '/' . $filename, null, 1);
+					$result = File::copy($tmpfname, $extractdir, null, 1);
 				}
 
 				@unlink($tmpfname);
@@ -133,7 +134,7 @@ class Archive implements LoggerAwareInterface
 				else
 				{
 					Folder::create($path);
-					$result = File::copy($tmpfname, $path . '/' . $filename, null, 1);
+					$result = File::copy($tmpfname, $extractdir, null, 1);
 				}
 
 				@unlink($tmpfname);

--- a/vendor/Joomla/Archive/Archive.php
+++ b/vendor/Joomla/Archive/Archive.php
@@ -10,15 +10,13 @@ namespace Joomla\Archive;
 
 use Joomla\Filesystem\File;
 use Joomla\Filesystem\Folder;
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerInterface;
 
 /**
  * An Archive handling class
  *
  * @since  1.0
  */
-class Archive implements LoggerAwareInterface
+class Archive
 {
 	/**
 	 * The array of instantiated archive adapters.
@@ -27,14 +25,6 @@ class Archive implements LoggerAwareInterface
 	 * @since  1.0
 	 */
 	protected $adapters = array();
-
-	/**
-	 * A logger.
-	 *
-	 * @var    LoggerInterface
-	 * @since  1.0
-	 */
-	private $logger;
 
 	/**
 	 * Holds the options array.
@@ -72,8 +62,8 @@ class Archive implements LoggerAwareInterface
 	{
 		$result = false;
 		$ext = pathinfo($archivename, PATHINFO_EXTENSION);
-		$filename = pathinfo($archivename, PATHINFO_FILENAME);
 		$path = pathinfo($archivename, PATHINFO_DIRNAME);
+		$filename = pathinfo($archivename, PATHINFO_FILENAME);
 
 		switch ($ext)
 		{
@@ -106,7 +96,7 @@ class Archive implements LoggerAwareInterface
 				else
 				{
 					Folder::create($path);
-					$result = File::copy($tmpfname, $extractdir, null, 1);
+					$result = File::copy($tmpfname, $extractdir, null, 0);
 				}
 
 				@unlink($tmpfname);
@@ -134,7 +124,7 @@ class Archive implements LoggerAwareInterface
 				else
 				{
 					Folder::create($path);
-					$result = File::copy($tmpfname, $extractdir, null, 1);
+					$result = File::copy($tmpfname, $extractdir, null, 0);
 				}
 
 				@unlink($tmpfname);
@@ -208,51 +198,5 @@ class Archive implements LoggerAwareInterface
 		}
 
 		return $this->adapters[$type];
-	}
-
-	/**
-	 * Get the logger.
-	 *
-	 * @return  LoggerInterface
-	 *
-	 * @since   1.0
-	 * @throws  \UnexpectedValueException
-	 */
-	public function getLogger()
-	{
-		if ($this->hasLogger())
-		{
-			return $this->logger;
-		}
-
-		throw new \UnexpectedValueException('Logger not set in ' . __CLASS__);
-	}
-
-	/**
-	 * Checks if a logger is available.
-	 *
-	 * @return  boolean
-	 *
-	 * @since   1.0
-	 */
-	public function hasLogger()
-	{
-		return ($this->logger instanceof LoggerInterface);
-	}
-
-	/**
-	 * Set the logger.
-	 *
-	 * @param   LoggerInterface  $logger  The logger.
-	 *
-	 * @return  Archive  This object to support chaining.
-	 *
-	 * @since   1.0
-	 */
-	public function setLogger(LoggerInterface $logger)
-	{
-		$this->logger = $logger;
-
-		return $this;
 	}
 }

--- a/vendor/Joomla/Archive/Archive.php
+++ b/vendor/Joomla/Archive/Archive.php
@@ -8,17 +8,17 @@
 
 namespace Joomla\Archive;
 
-use Joomla\Factory;
-use Joomla\Filesystem\Path;
 use Joomla\Filesystem\File;
 use Joomla\Filesystem\Folder;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * An Archive handling class
  *
  * @since  1.0
  */
-class Archive
+class Archive implements LoggerAwareInterface
 {
 	/**
 	 * The array of instantiated archive adapters.
@@ -26,7 +26,36 @@ class Archive
 	 * @var    array
 	 * @since  1.0
 	 */
-	protected static $adapters = array();
+	protected $adapters = array();
+
+	/**
+	 * A logger.
+	 *
+	 * @var    LoggerInterface
+	 * @since  1.0
+	 */
+	private $logger;
+
+	/**
+	 * Holds the options array.
+	 *
+	 * @var    mixed  Array or object that implements \ArrayAccess
+	 * @since  1.0
+	 */
+	protected $options = array();
+
+	/**
+	 * Create a new Archive object.
+	 *
+	 * @param  mixed  $options  An array of options or an object that implements \ArrayAccess
+	 *
+	 * @since  1.0
+	 */
+	public function __construct($options = array())
+	{
+		$this->options = $options;
+	}
+	
 
 	/**
 	 * Extract an archive file to a directory.
@@ -39,126 +68,80 @@ class Archive
 	 * @since   1.0
 	 * @throws  \InvalidArgumentException
 	 */
-	public static function extract($archivename, $extractdir)
+	public function extract($archivename, $extractdir)
 	{
-		$untar = false;
 		$result = false;
-		$ext = File::getExt(strtolower($archivename));
-
-		// Check if a tar is embedded...gzip/bzip2 can just be plain files!
-		if (File::getExt(File::stripExt(strtolower($archivename))) == 'tar')
-		{
-			$untar = true;
-		}
+		$ext = pathinfo($archivename, PATHINFO_EXTENSION);
+		$filename = pathinfo($archivename, PATHINFO_FILENAME);
 
 		switch ($ext)
 		{
 			case 'zip':
-				$adapter = self::getAdapter('zip');
-
-				if ($adapter)
-				{
-					$result = $adapter->extract($archivename, $extractdir);
-				}
+				$result = $this->getAdapter('zip')->extract($archivename, $extractdir);
 				break;
 
 			case 'tar':
-				$adapter = self::getAdapter('tar');
-
-				if ($adapter)
-				{
-					$result = $adapter->extract($archivename, $extractdir);
-				}
+				$result = $this->getAdapter('tar')->extract($archivename, $extractdir);
 				break;
 
 			case 'tgz':
-				// This format is a tarball gzip'd
-				$untar = true;
-
 			case 'gz':
 			case 'gzip':
 				// This may just be an individual file (e.g. sql script)
-				$adapter = self::getAdapter('gzip');
+				$tmpfname = $this->options['tmp_path'] . '/' . uniqid('gzip');
+				$gzresult = $this->getAdapter('gzip')->extract($archivename, $tmpfname);
 
-				if ($adapter)
+				if ($gzresult instanceof \Exception)
 				{
-					$config = Factory::getConfig();
-					$tmpfname = $config->get('tmp_path') . '/' . uniqid('gzip');
-					$gzresult = $adapter->extract($archivename, $tmpfname);
-
-					if ($gzresult instanceof \Exception)
-					{
-						@unlink($tmpfname);
-
-						return false;
-					}
-
-					if ($untar)
-					{
-						// Try to untar the file
-						$tadapter = self::getAdapter('tar');
-
-						if ($tadapter)
-						{
-							$result = $tadapter->extract($tmpfname, $extractdir);
-						}
-					}
-					else
-					{
-						$path = Path::clean($extractdir);
-						Folder::create($path);
-						$result = File::copy($tmpfname, $path . '/' . File::stripExt(basename(strtolower($archivename))), null, 1);
-					}
-
 					@unlink($tmpfname);
+
+					return false;
 				}
+
+				if ($ext === 'tgz' || stripos($filename, '.tar') !== false)
+				{
+					$result = $this->getAdapter('tar')->extract($tmpfname, $extractdir);
+				}
+				else
+				{
+					Folder::create($path);
+					$result = File::copy($tmpfname, $path . '/' . $filename, null, 1);
+				}
+
+				@unlink($tmpfname);
+
 				break;
 
 			case 'tbz2':
-				// This format is a tarball bzip2'd
-				$untar = true;
-
 			case 'bz2':
 			case 'bzip2':
 				// This may just be an individual file (e.g. sql script)
-				$adapter = self::getAdapter('bzip2');
+				$tmpfname = $this->options['tmp_path'] . '/' . uniqid('bzip2');
+				$bzresult = $this->getAdapter('bzip2')->extract($archivename, $tmpfname);
 
-				if ($adapter)
+				if ($bzresult instanceof \Exception)
 				{
-					$config = Factory::getConfig();
-					$tmpfname = $config->get('tmp_path') . '/' . uniqid('bzip2');
-					$bzresult = $adapter->extract($archivename, $tmpfname);
-
-					if ($bzresult instanceof \Exception)
-					{
-						@unlink($tmpfname);
-
-						return false;
-					}
-
-					if ($untar)
-					{
-						// Try to untar the file
-						$tadapter = self::getAdapter('tar');
-
-						if ($tadapter)
-						{
-							$result = $tadapter->extract($tmpfname, $extractdir);
-						}
-					}
-					else
-					{
-						$path = Path::clean($extractdir);
-						Folder::create($path);
-						$result = File::copy($tmpfname, $path . '/' . File::stripExt(basename(strtolower($archivename))), null, 1);
-					}
-
 					@unlink($tmpfname);
+
+					return false;
 				}
+
+				if ($ext === 'tbz2' || stripos($filename, '.tar') !== false)
+				{
+					$result = $this->getAdapter('tar')->extract($tmpfname, $extractdir);
+				}
+				else
+				{
+					Folder::create($path);
+					$result = File::copy($tmpfname, $path . '/' . $filename, null, 1);
+				}
+
+				@unlink($tmpfname);
+
 				break;
 
 			default:
-				throw new \InvalidArgumentException('Unknown Archive Type');
+				throw new \InvalidArgumentException(sprintf('Unknown archive type: %s', $ext));
 		}
 
 		if (!$result || $result instanceof \Exception)
@@ -167,6 +150,33 @@ class Archive
 		}
 
 		return true;
+	}
+
+	/**
+	 * Method to override the provided adapter with your own implementation.
+	 *
+	 * @param   string  $type      Name of the adapter to set.
+	 * @param   object  $adapter   Class which implements ExtractableInterface.
+	 * @param   object  $override  True to force override the adapter type.
+	 *
+	 * @return  Archive  This object for chaining.
+	 *
+	 * @since   1.0
+	 * @throws  \InvalidArgumentException
+	 */
+	public function setAdapter($type, $adapter, $override = true)
+	{
+		if (!($adapter instanceof ExtractableInterface))
+		{
+			throw new \InvalidArgumentException(sprintf('The provided %s adapter %s must implement Joomla\\Archive\\ExtractableInterface', $type), 500);
+		}
+
+		if ($override || !isset($this->adapters[$type]))
+		{
+			$this->adapters[$type] = $value;
+		}
+
+		return $this;
 	}
 
 	/**
@@ -179,21 +189,69 @@ class Archive
 	 * @since   1.0
 	 * @throws  \UnexpectedValueException
 	 */
-	public static function getAdapter($type)
+	public function getAdapter($type)
 	{
-		if (!isset(self::$adapters[$type]))
+		$type = strtolower($type);
+
+		if (!isset($this->adapters[$type]))
 		{
 			// Try to load the adapter object
 			$class = 'Joomla\\Archive\\' . ucfirst($type);
 
-			if (!class_exists($class))
+			if (!class_exists($class) || !$class::isSupported())
 			{
-				throw new \UnexpectedValueException(sprintf('Unable to load archive adapter %s.', $type) , 500);
+				throw new \UnexpectedValueException(sprintf('Archive adapter %s not found or supported.', $type), 500);
 			}
 
-			self::$adapters[$type] = new $class;
+			$this->adapters[$type] = new $class($this->options);
 		}
 
-		return self::$adapters[$type];
+		return $this->adapters[$type];
+	}
+
+	/**
+	 * Get the logger.
+	 *
+	 * @return  LoggerInterface
+	 *
+	 * @since   1.0
+	 * @throws  \UnexpectedValueException
+	 */
+	public function getLogger()
+	{
+		if ($this->hasLogger())
+		{
+			return $this->logger;
+		}
+
+		throw new \UnexpectedValueException('Logger not set in ' . __CLASS__);
+	}
+
+	/**
+	 * Checks if a logger is available.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   1.0
+	 */
+	public function hasLogger()
+	{
+		return ($this->logger instanceof LoggerInterface);
+	}
+
+	/**
+	 * Set the logger.
+	 *
+	 * @param   LoggerInterface  $logger  The logger.
+	 *
+	 * @return  Archive  This object to support chaining.
+	 *
+	 * @since   1.0
+	 */
+	public function setLogger(LoggerInterface $logger)
+	{
+		$this->logger = $logger;
+
+		return $this;
 	}
 }

--- a/vendor/Joomla/Archive/Archive.php
+++ b/vendor/Joomla/Archive/Archive.php
@@ -43,6 +43,9 @@ class Archive
 	 */
 	public function __construct($options = array())
 	{
+		// Make sure we have a tmp directory.
+		isset($options['tmp_path']) or $options['tmp_path'] = realpath(sys_get_temp_dir());
+
 		$this->options = $options;
 	}
 	
@@ -147,7 +150,7 @@ class Archive
 	 * Method to override the provided adapter with your own implementation.
 	 *
 	 * @param   string  $type      Name of the adapter to set.
-	 * @param   object  $adapter   Class which implements ExtractableInterface.
+	 * @param   string  $class     FQCN of your class which implements ExtractableInterface.
 	 * @param   object  $override  True to force override the adapter type.
 	 *
 	 * @return  Archive  This object for chaining.
@@ -155,16 +158,16 @@ class Archive
 	 * @since   1.0
 	 * @throws  \InvalidArgumentException
 	 */
-	public function setAdapter($type, $adapter, $override = true)
+	public function setAdapter($type, $class, $override = true)
 	{
-		if (!($adapter instanceof ExtractableInterface))
+		if (!($class instanceof ExtractableInterface))
 		{
 			throw new \InvalidArgumentException(sprintf('The provided %s adapter %s must implement Joomla\\Archive\\ExtractableInterface', $type), 500);
 		}
 
 		if ($override || !isset($this->adapters[$type]))
 		{
-			$this->adapters[$type] = $value;
+			$this->adapters[$type] = new $class($this->options);
 		}
 
 		return $this;

--- a/vendor/Joomla/Archive/Bzip2.php
+++ b/vendor/Joomla/Archive/Bzip2.php
@@ -27,27 +27,41 @@ class Bzip2 implements ExtractableInterface
 	private $data = null;
 
 	/**
+	 * Holds the options array.
+	 *
+	 * @var    mixed  Array or object that implements \ArrayAccess
+	 * @since  1.0
+	 */
+	protected $options = array();
+
+	/**
+	 * Create a new Archive object.
+	 *
+	 * @param  mixed  $options  An array of options or an object that implements \ArrayAccess
+	 *
+	 * @since  1.0
+	 */
+	public function __construct($options = array())
+	{
+		$this->options = $options;
+	}
+
+	/**
 	 * Extract a Bzip2 compressed file to a given path
 	 *
 	 * @param   string  $archive      Path to Bzip2 archive to extract
 	 * @param   string  $destination  Path to extract archive to
-	 * @param   array   $options      Extraction options [unused]
 	 *
 	 * @return  boolean  True if successful
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function extract($archive, $destination, array $options = array ())
+	public function extract($archive, $destination)
 	{
 		$this->data = null;
 
-		if (!extension_loaded('bz2'))
-		{
-			throw new \RuntimeException('The bz2 extension is not available.');
-		}
-
-		if (!isset($options['use_streams']) || $options['use_streams'] == false)
+		if (!isset($this->options['use_streams']) || $this->options['use_streams'] == false)
 		{
 			// Old style: read the whole file and then parse it
 			$this->data = file_get_contents($archive);

--- a/vendor/Joomla/Archive/ExtractableInterface.php
+++ b/vendor/Joomla/Archive/ExtractableInterface.php
@@ -26,7 +26,7 @@ interface ExtractableInterface
 	 *
 	 * @since   1.0
 	 */
-	public function extract($archive, $destination, array $options = array());
+	public function extract($archive, $destination);
 
 	/**
 	 * Tests whether this adapter can unpack files on this computer.

--- a/vendor/Joomla/Archive/Gzip.php
+++ b/vendor/Joomla/Archive/Gzip.php
@@ -41,27 +41,41 @@ class Gzip implements ExtractableInterface
 	private $data = null;
 
 	/**
+	 * Holds the options array.
+	 *
+	 * @var    mixed  Array or object that implements \ArrayAccess
+	 * @since  1.0
+	 */
+	protected $options = array();
+
+	/**
+	 * Create a new Archive object.
+	 *
+	 * @param  mixed  $options  An array of options or an object that implements \ArrayAccess
+	 *
+	 * @since  1.0
+	 */
+	public function __construct($options = array())
+	{
+		$this->options = $options;
+	}
+
+	/**
 	 * Extract a Gzip compressed file to a given path
 	 *
 	 * @param   string  $archive      Path to ZIP archive to extract
 	 * @param   string  $destination  Path to extract archive to
-	 * @param   array   $options      Extraction options [unused]
 	 *
 	 * @return  boolean  True if successful
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function extract($archive, $destination, array $options = array ())
+	public function extract($archive, $destination)
 	{
 		$this->data = null;
 
-		if (!extension_loaded('zlib'))
-		{
-			throw new \RuntimeException('The zlib extension is not available.');
-		}
-
-		if (!isset($options['use_streams']) || $options['use_streams'] == false)
+		if (!isset($this->options['use_streams']) || $this->options['use_streams'] == false)
 		{
 			$this->data = file_get_contents($archive);
 

--- a/vendor/Joomla/Archive/Gzip.php
+++ b/vendor/Joomla/Archive/Gzip.php
@@ -138,6 +138,7 @@ class Gzip implements ExtractableInterface
 			$output->close();
 			$input->close();
 		}
+
 		return true;
 	}
 

--- a/vendor/Joomla/Archive/README.md
+++ b/vendor/Joomla/Archive/README.md
@@ -1,1 +1,27 @@
 # The Archive Package
+
+The archive package will intelligently load the correct adapter for the specified archive type. It knows how to properly handle the following archive types:
+
+- zip
+- tar | tgz | tbz2
+- gz | gzip
+- bz2 | bzip2
+
+Loading files of the `t*` archive type will uncompress the archive using the appropriate adapter, and then extract via tar.
+
+## Requirements
+
+- PHP 5.3+
+- zlib extension for GZip support
+- bz2 extension for BZip2 support
+
+## Usage
+
+```php
+
+$options = array('tmp_path' => '/tmp');
+
+$archive = new Archive($options)
+
+$archive->extract(__DIR__ . '/archive.zip', __DIR__ . '/destination');
+```

--- a/vendor/Joomla/Archive/README.md
+++ b/vendor/Joomla/Archive/README.md
@@ -25,3 +25,32 @@ $archive = new Archive($options)
 
 $archive->extract(__DIR__ . '/archive.zip', __DIR__ . '/destination');
 ```
+
+## Overriding Adapters
+
+If you have a custom adapter you would like to use for extracting, this package allows you to override the defaults. Just implement `ExtractableInterface` when creating your adapter, and then use the `setAdapter` method to override.
+
+```php
+
+class MyZipAdapter implements \Joomla\Archive\ExtractableInterface
+{
+	public static function isSupported()
+	{
+		// Do you test
+		return true;
+	}
+
+	public function extract($archive, $destination)
+	{
+		// Your code
+	}
+}
+
+$archive = new Archive;
+
+// You need to pass the fully qualified class name.
+$archive->setAdapter('zip', '\\MyZipAdapter');
+
+// This will use your 
+$archive->extract('archive.zip', 'destination');
+```

--- a/vendor/Joomla/Archive/Tar.php
+++ b/vendor/Joomla/Archive/Tar.php
@@ -59,18 +59,37 @@ class Tar implements ExtractableInterface
 	private $metadata = null;
 
 	/**
+	 * Holds the options array.
+	 *
+	 * @var    mixed  Array or object that implements \ArrayAccess
+	 * @since  1.0
+	 */
+	protected $options = array();
+
+	/**
+	 * Create a new Archive object.
+	 *
+	 * @param  mixed  $options  An array of options or an object that implements \ArrayAccess
+	 *
+	 * @since  1.0
+	 */
+	public function __construct($options = array())
+	{
+		$this->options = $options;
+	}
+
+	/**
 	 * Extract a ZIP compressed file to a given path
 	 *
 	 * @param   string  $archive      Path to ZIP archive to extract
 	 * @param   string  $destination  Path to extract archive into
-	 * @param   array   $options      Extraction options [unused]
 	 *
 	 * @return  boolean True if successful
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function extract($archive, $destination, array $options = array())
+	public function extract($archive, $destination)
 	{
 		$this->data = null;
 		$this->metadata = null;

--- a/vendor/Joomla/Archive/Tests/ArchiveTest.php
+++ b/vendor/Joomla/Archive/Tests/ArchiveTest.php
@@ -40,7 +40,7 @@ class ArchiveTest extends \PHPUnit_Framework_TestCase
 			mkdir($this->outputPath, 0777);
 		}
 
-		$this->fixture = new Archive(array('tmp_path' => '/tmp'));
+		$this->fixture = new Archive;
 	}
 
 	/**

--- a/vendor/Joomla/Archive/Tests/ArchiveTest.php
+++ b/vendor/Joomla/Archive/Tests/ArchiveTest.php
@@ -11,7 +11,6 @@ use Joomla\Archive\Zip as ArchiveZip;
 use Joomla\Archive\Tar as ArchiveTar;
 use Joomla\Archive\Gzip as ArchiveGzip;
 use Joomla\Archive\Bzip2 as ArchiveBzip2;
-use Joomla\Factory;
 
 /**
  * Test class for Joomla\Archive\Archive.
@@ -20,7 +19,8 @@ use Joomla\Factory;
  */
 class ArchiveTest extends \PHPUnit_Framework_TestCase
 {
-	protected static $outputPath;
+	protected $fixture;
+	protected $outputPath;
 
 	/**
 	 * Sets up the fixture.
@@ -33,12 +33,14 @@ class ArchiveTest extends \PHPUnit_Framework_TestCase
 	{
 		parent::setUp();
 
-		self::$outputPath = __DIR__ . '/output';
+		$this->outputPath = __DIR__ . '/output';
 
-		if (!is_dir(self::$outputPath))
+		if (!is_dir($this->outputPath))
 		{
-			mkdir(self::$outputPath, 0777);
+			mkdir($this->outputPath, 0777);
 		}
+
+		$this->fixture = new Archive(array('tmp_path' => '/tmp'));
 	}
 
 	/**
@@ -50,7 +52,7 @@ class ArchiveTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testExtractZip()
 	{
-		if (!is_dir(self::$outputPath))
+		if (!is_dir($this->outputPath))
 		{
 			$this->markTestSkipped("Couldn't create folder.");
 
@@ -64,12 +66,12 @@ class ArchiveTest extends \PHPUnit_Framework_TestCase
 			return;
 		}
 
-		Archive::extract(__DIR__ . '/logo.zip', self::$outputPath);
-		$this->assertTrue(is_file(self::$outputPath . '/logo-zip.png'));
+		$this->fixture->extract(__DIR__ . '/logo.zip', $this->outputPath);
+		$this->assertTrue(is_file($this->outputPath . '/logo-zip.png'));
 
-		if (is_file(self::$outputPath . '/logo-zip.png'))
+		if (is_file($this->outputPath . '/logo-zip.png'))
 		{
-			unlink(self::$outputPath . '/logo-zip.png');
+			unlink($this->outputPath . '/logo-zip.png');
 		}
 	}
 
@@ -82,7 +84,7 @@ class ArchiveTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testExtractTar()
 	{
-		if (!is_dir(self::$outputPath))
+		if (!is_dir($this->outputPath))
 		{
 			$this->markTestSkipped("Couldn't create folder.");
 
@@ -96,12 +98,12 @@ class ArchiveTest extends \PHPUnit_Framework_TestCase
 			return;
 		}
 
-		Archive::extract(__DIR__ . '/logo.tar', self::$outputPath);
-		$this->assertTrue(is_file(self::$outputPath . '/logo-tar.png'));
+		$this->fixture->extract(__DIR__ . '/logo.tar', $this->outputPath);
+		$this->assertTrue(is_file($this->outputPath . '/logo-tar.png'));
 
-		if (is_file(self::$outputPath . '/logo-tar.png'))
+		if (is_file($this->outputPath . '/logo-tar.png'))
 		{
-			unlink(self::$outputPath . '/logo-tar.png');
+			unlink($this->outputPath . '/logo-tar.png');
 		}
 	}
 
@@ -114,14 +116,14 @@ class ArchiveTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testExtractGzip()
 	{
-		if (!is_dir(self::$outputPath))
+		if (!is_dir($this->outputPath))
 		{
 			$this->markTestSkipped("Couldn't create folder.");
 
 			return;
 		}
 
-		if (!is_writable(self::$outputPath) || !is_writable(Factory::getConfig()->get('tmp_path')))
+		if (!is_writable($this->outputPath) || !is_writable($this->fixture->options['tmp_path']))
 		{
 			$this->markTestSkipped("Folder not writable.");
 
@@ -135,12 +137,12 @@ class ArchiveTest extends \PHPUnit_Framework_TestCase
 			return;
 		}
 
-		Archive::extract(__DIR__ . '/logo.gz', self::$outputPath . '/logo-gz.png');
-		$this->assertTrue(is_file(self::$outputPath . '/logo-gz.png'));
+		$this->fixture->extract(__DIR__ . '/logo.gz', $this->outputPath . '/logo-gz.png');
+		$this->assertTrue(is_file($this->outputPath . '/logo-gz.png'));
 
-		if (is_file(self::$outputPath . '/logo-gz.png'))
+		if (is_file($this->outputPath . '/logo-gz.png'))
 		{
-			unlink(self::$outputPath . '/logo-gz.png');
+			unlink($this->outputPath . '/logo-gz.png');
 		}
 	}
 
@@ -153,14 +155,14 @@ class ArchiveTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testExtractBzip2()
 	{
-		if (!is_dir(self::$outputPath))
+		if (!is_dir($this->outputPath))
 		{
 			$this->markTestSkipped("Couldn't create folder.");
 
 			return;
 		}
 
-		if (!is_writable(self::$outputPath) || !is_writable(Factory::getConfig()->get('tmp_path')))
+		if (!is_writable($this->outputPath) || !is_writable($this->fixture->options['tmp_path']))
 		{
 			$this->markTestSkipped("Folder not writable.");
 
@@ -174,12 +176,12 @@ class ArchiveTest extends \PHPUnit_Framework_TestCase
 			return;
 		}
 
-		Archive::extract(__DIR__ . '/logo.bz2', self::$outputPath . '/logo-bz2.png');
-		$this->assertTrue(is_file(self::$outputPath . '/logo-bz2.png'));
+		$this->fixture->extract(__DIR__ . '/logo.bz2', $this->outputPath . '/logo-bz2.png');
+		$this->assertTrue(is_file($this->outputPath . '/logo-bz2.png'));
 
-		if (is_file(self::$outputPath . '/logo-bz2.png'))
+		if (is_file($this->outputPath . '/logo-bz2.png'))
 		{
-			unlink(self::$outputPath . '/logo-bz2.png');
+			unlink($this->outputPath . '/logo-bz2.png');
 		}
 	}
 
@@ -192,13 +194,13 @@ class ArchiveTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testGetAdapter()
 	{
-		$zip = Archive::getAdapter('zip');
+		$zip = $this->fixture->getAdapter('zip');
 		$this->assertInstanceOf('Joomla\\Archive\\Zip', $zip);
-		$bzip2 = Archive::getAdapter('bzip2');
+		$bzip2 = $this->fixture->getAdapter('bzip2');
 		$this->assertInstanceOf('Joomla\\Archive\\Bzip2', $bzip2);
-		$gzip = Archive::getAdapter('gzip');
+		$gzip = $this->fixture->getAdapter('gzip');
 		$this->assertInstanceOf('Joomla\\Archive\\Gzip', $gzip);
-		$tar = Archive::getAdapter('tar');
+		$tar = $this->fixture->getAdapter('tar');
 		$this->assertInstanceOf('Joomla\\Archive\\Tar', $tar);
 	}
 
@@ -212,6 +214,6 @@ class ArchiveTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testGetAdapterException()
 	{
-		$zip = Archive::getAdapter('unknown');
+		$zip = $this->fixture->getAdapter('unknown');
 	}
 }

--- a/vendor/Joomla/Archive/Zip.php
+++ b/vendor/Joomla/Archive/Zip.php
@@ -42,8 +42,16 @@ class Zip implements ExtractableInterface
 	 * @var    array
 	 * @since  1.0
 	 */
-	private $methods = array(0x0 => 'None', 0x1 => 'Shrunk', 0x2 => 'Super Fast', 0x3 => 'Fast', 0x4 => 'Normal', 0x5 => 'Maximum', 0x6 => 'Imploded',
-		0x8 => 'Deflated');
+	private $methods = array(
+		0x0 => 'None',
+		0x1 => 'Shrunk',
+		0x2 => 'Super Fast',
+		0x3 => 'Fast',
+		0x4 => 'Normal',
+		0x5 => 'Maximum',
+		0x6 => 'Imploded',
+		0x8 => 'Deflated'
+	);
 
 	/**
 	 * Beginning of central directory record.
@@ -86,6 +94,26 @@ class Zip implements ExtractableInterface
 	private $metadata = null;
 
 	/**
+	 * Holds the options array.
+	 *
+	 * @var    mixed  Array or object that implements \ArrayAccess
+	 * @since  1.0
+	 */
+	protected $options = array();
+
+	/**
+	 * Create a new Archive object.
+	 *
+	 * @param  mixed  $options  An array of options or an object that implements \ArrayAccess
+	 *
+	 * @since  1.0
+	 */
+	public function __construct($options = array())
+	{
+		$this->options = $options;
+	}
+
+	/**
 	 * Create a ZIP compressed file from an array of file data.
 	 *
 	 * @param   string  $archive  Path to save archive.
@@ -115,14 +143,13 @@ class Zip implements ExtractableInterface
 	 *
 	 * @param   string  $archive      Path to ZIP archive to extract
 	 * @param   string  $destination  Path to extract archive into
-	 * @param   array   $options      Extraction options [unused]
 	 *
 	 * @return  boolean  True if successful
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function extract($archive, $destination, array $options = array())
+	public function extract($archive, $destination)
 	{
 		if (!is_file($archive))
 		{
@@ -199,11 +226,6 @@ class Zip implements ExtractableInterface
 	{
 		$this->data = null;
 		$this->metadata = null;
-
-		if (!extension_loaded('zlib'))
-		{
-			throw new \RuntimeException('Zlib not supported');
-		}
 
 		$this->data = file_get_contents($archive);
 


### PR DESCRIPTION
This refactors the Archive package to be Object Oriented instead of just static wrappers of functionality. I've also added the ability to override any particular adapter type with your own implementation if you prefer via the `setAdapter` method.

I've also started the documentation on it, but need to add in how to use `setAdapter`. If you like the way this is going, I'll continue with it.
