### PR TITLE
Change meta endpoint to return CIDR addresses

### DIFF
--- a/src/Joomla/Github/Meta.php
+++ b/src/Joomla/Github/Meta.php
@@ -18,7 +18,7 @@ class Meta extends Object
 	/**
 	 * Method to get the authorized IP addresses for services
 	 *
-	 * @return  array  Authorized IP addresses
+	 * @return  array  Authorized IP addresses in CIDR format
 	 *
 	 * @since   1.0
 	 */
@@ -27,29 +27,6 @@ class Meta extends Object
 		// Build the request path.
 		$path = '/meta';
 
-		$githubIps = $this->processResponse($this->client->get($this->fetchUrl($path)), 200);
-
-		/*
-		 * The response body returns the IP addresses in CIDR format
-		 * Decode the response body and strip the subnet mask information prior to
-		 * returning the data to the user.  We're assuming quite a bit here that all
-		 * masks will be /32 as they are as of the time of development.
-		 */
-
-		$authorizedIps = array();
-
-		foreach ($githubIps as $key => $serviceIps)
-		{
-			// The first level contains an array of IPs based on the service
-			$authorizedIps[$key] = array();
-
-			foreach ($serviceIps as $serviceIp)
-			{
-				// The second level is each individual IP address, strip the mask here
-				$authorizedIps[$key][] = substr($serviceIp, 0, -3);
-			}
-		}
-
-		return $authorizedIps;
+		return $this->processResponse($this->client->get($this->fetchUrl($path)), 200);
 	}
 }

--- a/src/Joomla/Github/Tests/MetaTest.php
+++ b/src/Joomla/Github/Tests/MetaTest.php
@@ -44,7 +44,7 @@ class MetaTest extends \PHPUnit_Framework_TestCase
 	 * @var    string  Sample JSON string.
 	 * @since  1.0
 	 */
-	protected $sampleString = '{"hooks":["127.0.0.1/32","192.168.1.1/32"],"git":["127.0.0.1/32"]}';
+	protected $sampleString = '{"hooks":["127.0.0.1/32","192.168.1.1/32","10.10.1.1/27"],"git":["127.0.0.1/32"]}';
 
 	/**
 	 * @var    string  Sample JSON error message.
@@ -83,10 +83,9 @@ class MetaTest extends \PHPUnit_Framework_TestCase
 		$this->response->code = 200;
 		$this->response->body = $this->sampleString;
 
-		$decodedResponse = array(
-			'hooks' => array('127.0.0.1', '192.168.1.1'),
-			'git' => array('127.0.0.1')
-		);
+		$decodedResponse = new \stdClass;
+		$decodedResponse->hooks = array('127.0.0.1/32', '192.168.1.1/32', '10.10.1.1/27');
+		$decodedResponse->git   = array('127.0.0.1/32');
 
 		$this->client->expects($this->once())
 			->method('get')


### PR DESCRIPTION
Just after I wrote this endpoint, GitHub changed to using non /32 addresses.  So, instead of stripping the mask out in our object, we need to return the unaltered data object now.
