### PR TITLE
Don't try to close a connection that does not exist.

### DIFF
--- a/src/Joomla/Database/Mysqli/MysqliDriver.php
+++ b/src/Joomla/Database/Mysqli/MysqliDriver.php
@@ -82,7 +82,7 @@ class MysqliDriver extends DatabaseDriver
 	 */
 	public function __destruct()
 	{
-		if (is_callable(array($this->connection, 'close')))
+		if (is_callable(array($this->connection, 'close')) && array_filter(get_object_vars($this->connection))
 		{
 			mysqli_close($this->connection);
 		}


### PR DESCRIPTION
This generates warnings when the connection does not exist. Instead, don't even try to close it. 
