### PR TITLE
JForm url filter won't allow save blank after save with data

### DIFF
--- a/src/Joomla/Form/Form.php
+++ b/src/Joomla/Form/Form.php
@@ -1231,7 +1231,7 @@ class Form
 			case 'URL':
 				if (empty($value))
 				{
-					return;
+					return false;
 				}
 
 				$filterInput = new Filter\InputFilter;


### PR DESCRIPTION
If you have saved form data and then save blank, the url filter in JForm will save 'http:\' which is clearly not good.  This adds the missing return value for that case.  
