### PR TITLE
Fix Session Storage when using None.

### DIFF
--- a/src/Joomla/Session/Storage/None.php
+++ b/src/Joomla/Session/Storage/None.php
@@ -18,4 +18,14 @@ use Joomla\Session\Storage;
  */
 class None extends Storage
 {
+	/**
+	 * Register the functions of this class with PHP's session handler
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function register()
+	{
+	}
 }


### PR DESCRIPTION
<a href="https://github.com/joomla/joomla-platform/commit/7b31e884dc01b136a85f9602c5c0acd5e6cd4be8#libraries/joomla/session/storage/none.php">This commit</a> in the Platform should have removed only the <code>ini_set('session.save_handler', 'files'); </code> line, leaving the register() method empty. As a result of removing the entire method the session is cleared every time getSession() from Factory is called.
