### PR TITLE
Add colors to CLI applications

### DIFF
--- a/src/Joomla/Application/AbstractCliApplication.php
+++ b/src/Joomla/Application/AbstractCliApplication.php
@@ -10,6 +10,7 @@ namespace Joomla\Application;
 
 use Joomla\Registry\Registry;
 use Joomla\Input;
+use Joomla\Application\Cli\CliOutput;
 
 /**
  * Base class for a Joomla! command line application.
@@ -25,6 +26,11 @@ abstract class AbstractCliApplication extends AbstractApplication
 	private static $instance;
 
 	/**
+	 * @var CliOutput
+	 */
+	protected $output;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   Input\Cli  $input   An optional argument to provide dependency injection for the application's
@@ -34,9 +40,11 @@ abstract class AbstractCliApplication extends AbstractApplication
 	 *                              config object.  If the argument is a Registry object that object will become
 	 *                              the application's config object, otherwise a default config object is created.
 	 *
+	 * @param   CliOutput  $output  The output handler.
+	 *
 	 * @since   1.0
 	 */
-	public function __construct(Input\Cli $input = null, Registry $config = null)
+	public function __construct(Input\Cli $input = null, Registry $config = null, CliOutput $output = null)
 	{
 		// Close the application if we are not executed from the command line.
 		// @codeCoverageIgnoreStart
@@ -47,7 +55,7 @@ abstract class AbstractCliApplication extends AbstractApplication
 
 		// @codeCoverageIgnoreEnd
 
-		parent::__construct($input instanceof Input\Input ? $input : new Input\Cli);
+		parent::__construct($input instanceof Input\Input ? $input : new Input\Cli, $config);
 
 		// Set the execution datetime and timestamp;
 		$this->set('execution.datetime', gmdate('Y-m-d H:i:s'));
@@ -55,6 +63,18 @@ abstract class AbstractCliApplication extends AbstractApplication
 
 		// Set the current directory.
 		$this->set('cwd', getcwd());
+
+		$this->output = ($output instanceof CliOutput) ? $output : new Cli\Output\Stdout;
+	}
+
+	/**
+	 * Get an output object.
+	 *
+	 * @return CliOutput
+	 */
+	public function getOutput()
+	{
+		return $this->output;
 	}
 
 	/**
@@ -70,7 +90,7 @@ abstract class AbstractCliApplication extends AbstractApplication
 	 */
 	public function out($text = '', $nl = true)
 	{
-		fwrite(STDOUT, $text . ($nl ? "\n" : null));
+		$this->output->out($text, $nl);
 
 		return $this;
 	}

--- a/src/Joomla/Application/Cli/CliOutput.php
+++ b/src/Joomla/Application/Cli/CliOutput.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Cli;
+
+/**
+ * Class CliOutput
+ *
+ * @since  1.0
+ */
+abstract class CliOutput
+{
+	/**
+	 * @var ColorProcessor
+	 */
+	protected $processor;
+
+	/**
+	 * Write a string to an output handler.
+	 *
+	 * @param   string   $text  The text to display.
+	 * @param   boolean  $nl    True (default) to append a new line at the end of the output string.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @codeCoverageIgnore
+	 */
+	abstract public function out($text = '', $nl = true);
+}

--- a/src/Joomla/Application/Cli/ColorProcessor.php
+++ b/src/Joomla/Application/Cli/ColorProcessor.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Cli;
+
+/**
+ * Class ColorProcessor.
+ *
+ * @since  1.0
+ */
+class ColorProcessor
+{
+	public $noColors = false;
+
+	protected $tagFilter = '/<([a-z=;]+)>(.*?)<\/([a-z=;]+)>/';
+
+	protected static $stripFilter = '/<[\/]?[a-z=;]+>/';
+
+	protected $styles = array();
+
+	/**
+	 * Add a style.
+	 *
+	 * @param   string      $name   The style name.
+	 * @param   ColorStyle  $style  The color style.
+	 *
+	 * @return $this
+	 */
+	public function addStyle($name, ColorStyle $style)
+	{
+		$this->styles[$name] = $style;
+
+		return $this;
+	}
+
+	/**
+	 * Strip color tags from a string.
+	 *
+	 * @param   string  $string  The string.
+	 *
+	 * @return string
+	 */
+	public static function stripColors($string)
+	{
+		return preg_replace(self::$stripFilter, '', $string);
+	}
+
+	/**
+	 * Process a string.
+	 *
+	 * @param   string  $string  The string to process.
+	 *
+	 * @return string
+	 */
+	public function process($string)
+	{
+		preg_match_all($this->tagFilter, $string, $matches);
+
+		if (!$matches)
+		{
+			return $string;
+		}
+
+		foreach ($matches[0] as $i => $m)
+		{
+			if ($matches[1][$i] != $matches[3][$i])
+			{
+				continue;
+			}
+
+			if (array_key_exists($matches[1][$i], $this->styles))
+			{
+				// A named style.
+
+				$string = $this->replaceColors($string, $matches[1][$i], $matches[2][$i], $this->styles[$matches[1][$i]]);
+			}
+			elseif (strpos($matches[1][$i], '='))
+			{
+				// Custom format
+
+				$string = $this->replaceColors($string, $matches[1][$i], $matches[2][$i], ColorStyle::fromString($matches[1][$i]));
+			}
+		}
+
+		return $string;
+	}
+
+	/**
+	 * Replace color tags in a string.
+	 *
+	 * @param   string      $text   The original text.
+	 * @param   string      $tag    The matched tag.
+	 * @param   string      $match  The match.
+	 * @param   ColorStyle  $style  The color style to apply.
+	 *
+	 * @internal param array $matches The matching tags
+	 * @return mixed
+	 */
+	private function replaceColors($text, $tag, $match, Colorstyle $style)
+	{
+		$replace = $this->noColors
+			? $match
+			: "\033[" . $style . "m" . $match . "\033[0m";
+
+		return str_replace('<' . $tag . '>' . $match . '</' . $tag . '>', $replace, $text);
+	}
+}

--- a/src/Joomla/Application/Cli/ColorStyle.php
+++ b/src/Joomla/Application/Cli/ColorStyle.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Cli;
+
+/**
+ * Class ColorStyle
+ *
+ * @since  1.0
+ */
+final class ColorStyle
+{
+	/**
+	 * Known colors.
+	 *
+	 * @var array
+	 */
+	private static $knownColors = array(
+		'black'   => 0,
+		'red'     => 1,
+		'green'   => 2,
+		'yellow'  => 3,
+		'blue'    => 4,
+		'magenta' => 5,
+		'cyan'    => 6,
+		'white'   => 7,
+	);
+
+	/**
+	 * Known styles.
+	 *
+	 * @var array
+	 */
+	private static $knownOptions = array(
+		'bold'       => 1,
+		'underscore' => 4,
+		'blink'      => 5,
+		'reverse'    => 7,
+	);
+
+	/**
+	 * Foreground base value.
+	 *
+	 * @var int
+	 */
+	private static $fgBase = 30;
+
+	/**
+	 * Background base value.
+	 *
+	 * @var int
+	 */
+	private static $bgBase = 40;
+
+	/**
+	 * Foreground color.
+	 *
+	 * @var int
+	 */
+	private $fgColor = 0;
+
+	/**
+	 * Background color.
+	 *
+	 * @var int
+	 */
+	private $bgColor = 0;
+
+	/**
+	 * Style options.
+	 *
+	 * @var array
+	 */
+	private $options = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   string  $fg       Foreground color.
+	 * @param   string  $bg       Background color.
+	 * @param   array   $options  Style options.
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	public function __construct($fg = '', $bg = '', $options = array())
+	{
+		if ($fg)
+		{
+			if (false == array_key_exists($fg, self::$knownColors))
+			{
+				throw new \InvalidArgumentException(
+					sprintf('Invalid foreground color "%1$s" [%2$s]',
+						$fg,
+						implode(', ', $this->getKnownColors())
+					)
+				);
+			}
+
+			$this->fgColor = self::$fgBase + self::$knownColors[$fg];
+		}
+
+		if ($bg)
+		{
+			if (false == array_key_exists($bg, self::$knownColors))
+			{
+				throw new \InvalidArgumentException(
+					sprintf('Invalid background color "%1$s" [%2$s]',
+						$bg,
+						implode(', ', $this->getKnownColors())
+					)
+				);
+			}
+
+			$this->bgColor = self::$bgBase + self::$knownColors[$bg];
+		}
+
+		foreach ($options as $option)
+		{
+			if (false == array_key_exists($option, self::$knownOptions))
+			{
+				throw new \InvalidArgumentException(
+					sprintf('Invalid option "%1$s" [%2$s]',
+						$option,
+						implode(', ', $this->getKnownOptions())
+					)
+				);
+			}
+
+			$this->options[] = $option;
+		}
+	}
+
+	/**
+	 * Create a color style from a parameter string.
+	 *
+	 * Example: fg=red;bg=blue;options=bold,blink
+	 *
+	 * @param   string  $string  The parameter string.
+	 *
+	 * @throws \RuntimeException
+	 * @return ColorStyle
+	 */
+	public static function fromString($string)
+	{
+		$fg = '';
+		$bg = '';
+		$options = array();
+
+		$parts = explode(';', $string);
+
+		foreach ($parts as $part)
+		{
+			$subParts = explode('=', $part);
+
+			if (count($subParts) < 2)
+			{
+				continue;
+			}
+
+			switch ($subParts[0])
+			{
+				case 'fg':
+					$fg = $subParts[1];
+					break;
+
+				case 'bg':
+					$bg = $subParts[1];
+					break;
+
+				case 'options':
+					$options = explode(',', $subParts[1]);
+					break;
+
+				default:
+					throw new \RuntimeException('Invalid option');
+					break;
+			}
+		}
+
+		return new self($fg, $bg, $options);
+	}
+
+	/**
+	 * Get the translated color code.
+	 *
+	 * @return string
+	 */
+	public function getStyle()
+	{
+		$values = array();
+
+		if ($this->fgColor)
+		{
+			$values[] = $this->fgColor;
+		}
+
+		if ($this->bgColor)
+		{
+			$values[] = $this->bgColor;
+		}
+
+		foreach ($this->options as $option)
+		{
+			$values[] = self::$knownOptions[$option];
+		}
+
+		return implode(';', $values);
+	}
+
+	/**
+	 * Convert to a string.
+	 *
+	 * @return string
+	 */
+	public function __toString()
+	{
+		return $this->getStyle();
+	}
+
+	/**
+	 * Get the known colors.
+	 *
+	 * @return array
+	 */
+	public function getKnownColors()
+	{
+		return array_keys(self::$knownColors);
+	}
+
+	/**
+	 * Get the known options.
+	 *
+	 * @return array
+	 */
+	public function getKnownOptions()
+	{
+		return array_keys(self::$knownOptions);
+	}
+}

--- a/src/Joomla/Application/Cli/Output/Stdout.php
+++ b/src/Joomla/Application/Cli/Output/Stdout.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Cli\Output;
+
+use Joomla\Application\Cli\CliOutput;
+use Joomla\Application\Cli\ColorStyle;
+use Joomla\Application\Cli\ColorProcessor;
+
+/**
+ * Class Stdout.
+ *
+ * @since  1.0
+ */
+class Stdout extends CliOutput
+{
+	public $noColors = false;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->processor = new ColorProcessor;
+
+		$this->addPredefinedStyles();
+	}
+
+	/**
+	 * Set a processor.
+	 *
+	 * @param   ColorProcessor  $processor  The color processor.
+	 *
+	 * @return $this
+	 */
+	public function setProcessor(ColorProcessor $processor)
+	{
+		$this->processor = $processor;
+
+		return $this;
+	}
+
+	/**
+	 * Get a processor.
+	 *
+	 * @return ColorProcessor
+	 */
+	public function getProcessor()
+	{
+		return $this->processor;
+	}
+
+	/**
+	 * Write a string to standard output.
+	 *
+	 * @param   string   $text  The text to display.
+	 * @param   boolean  $nl    True (default) to append a new line at the end of the output string.
+	 *
+	 * @since   1.0
+	 * @return $this
+	 */
+	public function out($text = '', $nl = true)
+	{
+		fwrite(STDOUT, $this->processor->process($text) . ($nl ? "\n" : null));
+
+		return $this;
+	}
+
+	/**
+	 * Add some predefined styles.
+	 *
+	 * @return $this
+	 */
+	private function addPredefinedStyles()
+	{
+		$this->processor->addStyle(
+			'info',
+			new ColorStyle('green', '', array('bold'))
+		);
+
+		$this->processor->addStyle(
+			'comment',
+			new ColorStyle('yellow', '', array('bold'))
+		);
+
+		$this->processor->addStyle(
+			'question',
+			new ColorStyle('black', 'cyan')
+		);
+
+		$this->processor->addStyle(
+			'error',
+			new ColorStyle('white', 'red')
+		);
+
+		return $this;
+	}
+}

--- a/src/Joomla/Application/Cli/Output/Xml.php
+++ b/src/Joomla/Application/Cli/Output/Xml.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Cli\Output;
+
+use Joomla\Application\Cli\CliOutput;
+
+/**
+ * Class Xml.
+ *
+ * @since  1.0
+ */
+class Xml extends CliOutput
+{
+	/**
+	 * Write a string to standard output.
+	 *
+	 * @param   string   $text  The text to display.
+	 * @param   boolean  $nl    True (default) to append a new line at the end of the output string.
+	 *
+	 * @throws \RuntimeException
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @codeCoverageIgnore
+	 */
+	public function out($text = '', $nl = true)
+	{
+		fwrite(STDOUT, $text . ($nl ? "\n" : null));
+	}
+}

--- a/src/Joomla/Application/README.md
+++ b/src/Joomla/Application/README.md
@@ -172,3 +172,49 @@ You can provide customised implementations these methods by creating the followi
 * `mockWebSet`
 * `mockWebSetBody`
 * `mockWebSetHeader`
+
+## Colors for CLI Applications
+
+It is possible to use colors on an ANSI enabled terminal.
+
+```php
+// Green text
+$this->out('<info>foo</info>');
+
+// Yellow text
+$this->out('<comment>foo</comment>');
+
+// Black text on a cyan background
+$this->out('<question>foo</question>');
+
+// White text on a red background
+$this->out('<error>foo</error>');
+```
+
+You can also create your own styles.
+
+```php
+use Joomla\Application\Cli\Colorstyle;
+
+$style = new Colorstyle('yellow', 'red', array('bold', 'blink'));
+$this->getOutput()->addStyle('fire', $style);
+$this->out('<fire>foo</fire>');
+
+```
+
+Available foreground and background colors are: black, red, green, yellow, blue, magenta, cyan and white.
+
+And available options are: bold, underscore, blink and reverse.
+
+You can also set these colors and options inside the tagname:
+
+```php
+// Green text
+$this->out('<fg=green>foo</fg=green>');
+
+// Black text on a cyan background
+$this->out('<fg=black;bg=cyan>foo</fg=black;bg=cyan>');
+
+// Bold text on a yellow background
+$this->out('<bg=yellow;options=bold>foo</bg=yellow;options=bold>');
+```

--- a/src/Joomla/Application/Tests/AbstractCliApplicationTest.php
+++ b/src/Joomla/Application/Tests/AbstractCliApplicationTest.php
@@ -23,7 +23,7 @@ class AbstractCliApplicationTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * An instance of the object to test.
 	 *
-	 * @var    Cli
+	 * @var   AbstractCliApplication
 	 * @since  1.0
 	 */
 	protected $instance;
@@ -99,5 +99,18 @@ class AbstractCliApplicationTest extends \PHPUnit_Framework_TestCase
 	{
 		// Get a new ConcreteCli instance.
 		$this->instance = new ConcreteCli;
+	}
+
+	/**
+	 * Test the getOutput() method.
+	 *
+	 * @return void
+	 */
+	public function testGetOutput()
+	{
+		$this->assertInstanceOf(
+			'Joomla\Application\Cli\Output\Stdout',
+			$this->instance->getOutput()
+		);
 	}
 }

--- a/src/Joomla/Application/Tests/Cli/ColorProcessorTest.php
+++ b/src/Joomla/Application/Tests/Cli/ColorProcessorTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Tests;
+
+use Joomla\Application\Cli\ColorProcessor;
+use Joomla\Application\Cli\ColorStyle;
+
+/**
+ * Test class.
+ *
+ * @since  1.0
+ */
+class ColorProcessorTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * @var ColorProcessor
+	 */
+	protected $object;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp()
+	{
+		$this->object = new ColorProcessor;
+	}
+
+	/**
+	 * @covers Joomla\Application\Cli\ColorProcessor::addStyle
+	 */
+	public function testAddStyle()
+	{
+		$style = new ColorStyle('red');
+		$this->object->addStyle('foo', $style);
+
+		$this->assertThat(
+			$this->object->process('<foo>foo</foo>'),
+			$this->equalTo('[31mfobo[0m')
+		);
+	}
+
+	/**
+	 * @covers Joomla\Application\Cli\ColorProcessor::stripColors
+	 */
+	public function testStripColors()
+	{
+		$this->assertThat(
+			$this->object->stripColors('<foo>foo</foo>'),
+			$this->equalTo('foo')
+		);
+	}
+
+	/**
+	 * @covers Joomla\Application\Cli\ColorProcessor::process
+	 */
+	public function testProcess()
+	{
+		$this->assertThat(
+			$this->object->process('<fg=red>foo</fg=red>'),
+			$this->equalTo('[31mfoo[0m')
+		);
+	}
+
+	/**
+	 * @covers Joomla\Application\Cli\ColorProcessor::process
+	 */
+	public function testProcessNamed()
+	{
+		$style = new ColorStyle('red');
+		$this->object->addStyle('foo', $style);
+
+		$this->assertThat(
+			$this->object->process('<foo>foo</foo>'),
+			$this->equalTo('[31mfoo[0m')
+		);
+	}
+
+	/**
+	 * @covers Joomla\Application\Cli\ColorProcessor::replaceColors
+	 */
+	public function testProcessReplace()
+	{
+		$this->assertThat(
+			$this->object->process('<fg=red>foo</fg=red>'),
+			$this->equalTo('[31mfoo[0m')
+		);
+	}
+}

--- a/src/Joomla/Application/Tests/Cli/ColorProcessorTest.php
+++ b/src/Joomla/Application/Tests/Cli/ColorProcessorTest.php
@@ -40,7 +40,7 @@ class ColorProcessorTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertThat(
 			$this->object->process('<foo>foo</foo>'),
-			$this->equalTo('[31mfobo[0m')
+			$this->equalTo('[31mfoo[0m')
 		);
 	}
 

--- a/src/Joomla/Application/Tests/Cli/ColorStyleTest.php
+++ b/src/Joomla/Application/Tests/Cli/ColorStyleTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Cli\Tests;
+
+/**
+ * Test class.
+ *
+ * @since  1.0
+ */
+class ColorStyleTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * @var ColorStyle
+	 */
+	protected $object;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return void
+	 */
+	protected function setUp()
+	{
+		$this->object = new ColorStyle('red', 'white', array('blink'));
+	}
+
+	/**
+	 * Test the GetStyle method.
+	 *
+	 * @covers Joomla\Application\Cli\ColorStyle::getStyle
+	 *
+	 * @return void
+	 */
+	public function testGetStyle()
+	{
+		$this->assertThat(
+			$this->object->getStyle(),
+			$this->equalTo('31;47;5')
+		);
+	}
+
+	/**
+	 * Test the ToString method.
+	 *
+	 * @return void
+	 */
+	public function testToString()
+	{
+		$this->assertThat(
+			$this->object->__toString(),
+			$this->equalTo('31;47;5')
+		);
+	}
+
+	/**
+	 * Test the __construct method.
+	 *
+	 * @return void
+	 */
+	public function fromString()
+	{
+		$style = new ColorStyle('white', 'red', array('blink', 'bold'));
+
+		$this->assertThat(
+			$this->object->fromString('fg=white;bg=red;options=blink,bold'),
+			$this->equalTo($style)
+		);
+	}
+
+	/**
+	 * Test the fromString method.
+	 *
+	 * @expectedException \RuntimeException
+	 *
+	 * @return void
+	 */
+	public function testFromStringInvalid()
+	{
+		$this->object->fromString('XXX;XX=YY');
+	}
+
+	/**
+	 * Test the __construct method.
+	 *
+	 * @expectedException \InvalidArgumentException
+	 *
+	 * @return void
+	 */
+	public function testConstructInvalid1()
+	{
+		new ColorStyle('INVALID');
+	}
+
+	/**
+	 * Test the __construct method.
+	 *
+	 * @expectedException \InvalidArgumentException
+	 *
+	 * @return void
+	 */
+	public function testConstructInvalid2()
+	{
+		new ColorStyle('', 'INVALID');
+	}
+
+	/**
+	 * Test the __construct method.
+	 *
+	 * @expectedException \InvalidArgumentException
+	 *
+	 * @return void
+	 */
+	public function testConstructInvalid3()
+	{
+		new ColorStyle('', '', array('INVALID'));
+	}
+}

--- a/src/Joomla/Application/Tests/Cli/ColorStyleTest.php
+++ b/src/Joomla/Application/Tests/Cli/ColorStyleTest.php
@@ -6,6 +6,8 @@
 
 namespace Joomla\Application\Cli\Tests;
 
+use Joomla\Application\Cli\ColorStyle;
+
 /**
  * Test class.
  *


### PR DESCRIPTION
This will add the possibility to use colors in CLI applications.

**Disclaimer**: This has been inspired by reading the documentation of [symfony/console](http://symfony.com/doc/master/components/console/introduction.html) which has been copied almost verbatim to our [readme.md](https://github.com/elkuku/joomla-framework/blob/cli-application/src/Joomla/Application/README.md), included here for reference:
The code, however, is mine ;)
## Colors for CLI Applications

It is possible to use colors on an ANSI enabled terminal.

``` php
// Green text
$this->out('<info>foo</info>');

// Yellow text
$this->out('<comment>foo</comment>');

// Black text on a cyan background
$this->out('<question>foo</question>');

// White text on a red background
$this->out('<error>foo</error>');
```

You can also create your own styles.

``` php
use Joomla\Application\Cli\Colorstyle;

$style = new Colorstyle('yellow', 'red', array('bold', 'blink'));
$this->getOutput()->addStyle('fire', $style);
$this->out('<fire>foo</fire>');

```

Available foreground and background colors are: black, red, green, yellow, blue, magenta, cyan and white.

And available options are: bold, underscore, blink and reverse.

You can also set these colors and options inside the tagname:

``` php
// Green text
$this->out('<fg=green>foo</fg=green>');

// Black text on a cyan background
$this->out('<fg=black;bg=cyan>foo</fg=black;bg=cyan>');

// Bold text on a yellow background
$this->out('<bg=yellow;options=bold>foo</bg=yellow;options=bold>');
```
