### PR TITLE
Remove coupling to Factory::getLanguage()

### DIFF
--- a/src/Joomla/Factory.php
+++ b/src/Joomla/Factory.php
@@ -62,14 +62,6 @@ abstract class Factory
 	public static $session = null;
 
 	/**
-	 * Language object instance
-	 *
-	 * @var    Language
-	 * @since  1.0
-	 */
-	public static $language = null;
-
-	/**
 	 * Driver object instance
 	 *
 	 * @var    DatabaseDriver
@@ -126,26 +118,6 @@ abstract class Factory
 		}
 
 		return self::$session;
-	}
-
-	/**
-	 * Get a language object.
-	 *
-	 * Returns the global {@link JLanguage} object, only creating it if it doesn't already exist.
-	 *
-	 * @return  Language object
-	 *
-	 * @see     Language
-	 * @since   1.0
-	 */
-	public static function getLanguage()
-	{
-		if (!self::$language)
-		{
-			self::$language = self::createLanguage();
-		}
-
-		return self::$language;
 	}
 
 	/**
@@ -281,24 +253,6 @@ abstract class Factory
 		$db->setDebug($debug);
 
 		return $db;
-	}
-
-	/**
-	 * Create a language object
-	 *
-	 * @return  Language object
-	 *
-	 * @see     Language
-	 * @since   1.0
-	 */
-	protected static function createLanguage()
-	{
-		$conf = self::getConfig();
-		$locale = $conf->get('language');
-		$debug = $conf->get('debug_lang');
-		$lang = Language::getInstance($locale, $debug);
-
-		return $lang;
 	}
 
 	/**

--- a/src/Joomla/Filter/OutputFilter.php
+++ b/src/Joomla/Filter/OutputFilter.php
@@ -8,7 +8,7 @@
 
 namespace Joomla\Filter;
 
-use Joomla\Factory;
+use Joomla\Language\Language;
 use Joomla\String\String;
 
 /**
@@ -98,7 +98,7 @@ class OutputFilter
 		// Remove any '-' from the string since they will be used as concatenaters
 		$str = str_replace('-', ' ', $string);
 
-		$lang = Factory::getLanguage();
+		$lang = Language::getInstance();
 		$str = $lang->transliterate($str);
 
 		// Trim white spaces at beginning and end of alias and make lowercase

--- a/src/Joomla/Filter/composer.json
+++ b/src/Joomla/Filter/composer.json
@@ -7,6 +7,7 @@
     "license": "GPL-2.0+",
     "require": {
         "php": ">=5.3.10",
+        "joomla/language": "dev-master",
         "joomla/string": "dev-master"
     },
     "target-dir": "Joomla/Filter",

--- a/src/Joomla/Form/Form.php
+++ b/src/Joomla/Form/Form.php
@@ -11,6 +11,7 @@ namespace Joomla\Form;
 use Joomla\Factory;
 use Joomla\Filter;
 use Joomla\Date\Date;
+use Joomla\Language\Language;
 use Joomla\Language\Text;
 use Joomla\Filesystem\Path;
 use Joomla\Registry\Registry;
@@ -1702,7 +1703,7 @@ class Form
 
 			if (($translate = $element['translate_default']) && ((string) $translate == 'true' || (string) $translate == '1'))
 			{
-				$lang = Factory::getLanguage();
+				$lang = Language::getInstance();
 
 				if ($lang->hasKey($default))
 				{

--- a/src/Joomla/Form/Tests/JFormTest.php
+++ b/src/Joomla/Form/Tests/JFormTest.php
@@ -6,8 +6,8 @@
 
 namespace Joomla\Form\Tests;
 
+use Joomla\Language\Language;
 use Joomla\Language\Text;
-use Joomla\Factory;
 use Joomla\Form\Form;
 use Joomla\Form\Rule;
 
@@ -1101,7 +1101,7 @@ class JFormTest extends \PHPUnit_Framework_TestCase
 			' The method should return a simple input text field whose value is untranslated since the DEFAULT_KEY does not exist in the language.'
 		);
 
-		$lang = Factory::getLanguage();
+		$lang = Language::getInstance();
 		$debug = $lang->setDebug(true);
 		$this->assertThat(
 			$form->getInput('translate_default'),

--- a/src/Joomla/Language/Language.php
+++ b/src/Joomla/Language/Language.php
@@ -293,11 +293,23 @@ class Language
 	 *
 	 * @since   1.0
 	 */
-	public static function getInstance($lang, $debug = false)
+	public static function getInstance($lang = null, $debug = false)
 	{
 		if (!isset(self::$languages[$lang . $debug]))
 		{
-			self::$languages[$lang . $debug] = new self($lang, $debug);
+			$language = new self($lang, $debug);
+
+			self::$languages[$lang . $debug] = $language;
+
+			/*
+			 * Check if Language was instantiated with a null $lang param;
+			 * if so, retrieve the language code from the object and store
+			 * the instance with the language code as well
+			 */
+			if (is_null($lang))
+			{
+				self::$languages[$language->getLanguage() . $debug] = $language;
+			}
 		}
 
 		return self::$languages[$lang . $debug];
@@ -1201,6 +1213,18 @@ class Language
 		}
 
 		return $dir;
+	}
+
+	/**
+	 * Get the current language code.
+	 *
+	 * @return  string  The language code
+	 *
+	 * @since   1.0
+	 */
+	public function getLanguage()
+	{
+		return $this->lang;
 	}
 
 	/**

--- a/src/Joomla/Language/Tests/LanguageTest.php
+++ b/src/Joomla/Language/Tests/LanguageTest.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/data/language/en-GB/en-GB.localise.php';
 
 use Joomla\Language\Language;
 use Joomla\Filesystem\Folder;
+use Joomla\Test\TestHelper;
 
 /**
  * Test class for Joomla\Language\Language.
@@ -60,13 +61,28 @@ class LanguageTest extends PHPUnit_Framework_TestCase
 	 * Test...
 	 *
 	 * @covers Joomla\Language\Language::getInstance
+	 * @covers Joomla\Language\Language::getLanguage
 	 *
 	 * @return void
 	 */
-	public function testGetInstance()
+	public function testGetInstanceAndLanguage()
 	{
 		$instance = Language::getInstance(null);
 		$this->assertInstanceOf('Joomla\Language\Language', $instance);
+
+		$this->assertEquals(
+			TestHelper::getValue($instance, 'default'),
+			$instance->getLanguage(),
+			'Asserts that getInstance when called with a null language returns the default language.  Line: ' . __LINE__
+		);
+
+		$instance = Language::getInstance('es-ES');
+
+		$this->assertEquals(
+			'es-ES',
+			$instance->getLanguage(),
+			'Asserts that getInstance when called with a specific language returns that language.  Line: ' . __LINE__
+		);
 	}
 
 	/**

--- a/src/Joomla/Language/Text.php
+++ b/src/Joomla/Language/Text.php
@@ -8,8 +8,6 @@
 
 namespace Joomla\Language;
 
-use Joomla\Factory;
-
 /**
  * Text handling class.
  *
@@ -44,7 +42,7 @@ class Text
 	 */
 	public static function _($string, $jsSafe = false, $interpretBackSlashes = true, $script = false)
 	{
-		$lang = Factory::getLanguage();
+		$lang = Language::getInstance();
 
 		if (is_array($jsSafe))
 		{
@@ -99,7 +97,7 @@ class Text
 	 */
 	public static function alt($string, $alt, $jsSafe = false, $interpretBackSlashes = true, $script = false)
 	{
-		$lang = Factory::getLanguage();
+		$lang = Language::getInstance();
 
 		if ($lang->hasKey($string . '_' . $alt))
 		{
@@ -140,7 +138,7 @@ class Text
 	 */
 	public static function plural($string, $n)
 	{
-		$lang = Factory::getLanguage();
+		$lang = Language::getInstance();
 		$args = func_get_args();
 		$count = count($args);
 
@@ -223,7 +221,7 @@ class Text
 	 */
 	public static function sprintf($string)
 	{
-		$lang = Factory::getLanguage();
+		$lang = Language::getInstance();
 		$args = func_get_args();
 		$count = count($args);
 
@@ -267,7 +265,7 @@ class Text
 	 */
 	public static function printf($string)
 	{
-		$lang = Factory::getLanguage();
+		$lang = Language::getInstance();
 		$args = func_get_args();
 		$count = count($args);
 
@@ -325,7 +323,7 @@ class Text
 		if ($string !== null)
 		{
 			// Normalize the key and translate the string.
-			self::$strings[strtoupper($string)] = Factory::getLanguage()->_($string, $jsSafe, $interpretBackSlashes);
+			self::$strings[strtoupper($string)] = Language::getInstance()->_($string, $jsSafe, $interpretBackSlashes);
 		}
 
 		return self::$strings;

--- a/src/Joomla/Language/composer.json
+++ b/src/Joomla/Language/composer.json
@@ -10,7 +10,8 @@
         "joomla/string": "dev-master"
     },
     "require-dev": {
-    	"joomla/filesystem": "dev-master"
+        "joomla/filesystem": "dev-master",
+        "joomla/test": "dev-master"
     },
     "target-dir": "Joomla/Language",
     "minimum-stability": "dev",


### PR DESCRIPTION
This is a very crude decoupling of the Framework to `Factory::getLanguage()`.  This modifies `Language::getInstance()` to accept a null `$lang` param and instantiate the Language class (using the `$default` property to set the language) and stores both the nulled input and the language input to the `$instances` container.  I haven't taken a look at removing said container for the moment, but since we're on a battle against statics, this is surely next.

What would probably be the best solution, IMO, would be the downstream application to handle loading the Language object allowing us to drop `Language::getInstance()` and the static container.  But, that's all in due time.
