### PR TITLE
Duplicate debug handling in Factory::getDbo()

### DIFF
--- a/src/Joomla/Factory.php
+++ b/src/Joomla/Factory.php
@@ -134,12 +134,7 @@ abstract class Factory
 	{
 		if (!self::$database)
 		{
-			// Get the debug configuration setting
-			$conf = self::getConfig();
-			$debug = $conf->get('debug');
-
 			self::$database = self::createDbo();
-			self::$database->setDebug($debug);
 		}
 
 		return self::$database;


### PR DESCRIPTION
An odd error reported at http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31108 led to it being pointed out that setDebug() is being run in both `getDbo()` and `createDbo()`.  This PR matches the proposed patch to the CMS and drops the handling in `getDbo()`.

I know we want to get rid of this code, but while it's in the repo, it might as well be efficient code ;-)
