### PR TITLE
Add missing GitHub hook events

### DIFF
--- a/src/Joomla/Github/Package/Repositories/Hooks.php
+++ b/src/Joomla/Github/Package/Repositories/Hooks.php
@@ -26,8 +26,8 @@ class Hooks extends Package
 	 * @since  1.0
 	 */
 	protected $events = array(
-		'push', 'issues', 'issue_comment', 'commit_comment', 'pull_request', 'gollum', 'watch', 'download', 'fork', 'fork_apply',
-		'member', 'public', 'status'
+		'push', 'issues', 'issue_comment', 'commit_comment', 'pull_request', 'pull_request_review_comment', 'gollum',
+		'watch', 'download', 'fork', 'fork_apply', 'member', 'public', 'team_add', 'status'
 	);
 
 	/**


### PR DESCRIPTION
This will add GitHub hook events that are missing in our API implemtation.
See: http://developer.github.com/v3/repos/hooks/
