### PR TITLE
Soft-couple Language package to Filter package

### DIFF
--- a/src/Joomla/Filter/README.md
+++ b/src/Joomla/Filter/README.md
@@ -20,3 +20,5 @@ Alternatively, you can simply run the following from the command line:
 composer init --stability="dev"
 composer require joomla/filter "dev-master"
 ```
+
+Note that the `Joomla\Language` package is an optional dependency and is only required if the application requires the use of `OutputFilter::stringURLSafe`.

--- a/src/Joomla/Filter/composer.json
+++ b/src/Joomla/Filter/composer.json
@@ -9,6 +9,9 @@
         "php": ">=5.3.10",
         "joomla/string": "dev-master"
     },
+    "require-dev": {
+        "joomla/language": "dev-master",
+    },
     "suggest": {
         "joomla/language": "Required only if you want to use `OutputFilter::stringURLSafe`."
     },

--- a/src/Joomla/Filter/composer.json
+++ b/src/Joomla/Filter/composer.json
@@ -7,8 +7,10 @@
     "license": "GPL-2.0+",
     "require": {
         "php": ">=5.3.10",
-        "joomla/language": "dev-master",
         "joomla/string": "dev-master"
+    },
+    "suggest": {
+        "joomla/language": "Required only if you want to use `OutputFilter::stringURLSafe`."
     },
     "target-dir": "Joomla/Filter",
     "minimum-stability": "dev",


### PR DESCRIPTION
This makes the Language package dependency for the Filter package
optional as it is is only required when `OutputFilter::stringURLSafe`
is used by the application.
