### PR TITLE
Add support for ServiceProviders to the DI Container

### DIFF
--- a/src/Joomla/DI/Container.php
+++ b/src/Joomla/DI/Container.php
@@ -340,5 +340,19 @@ class Container
 	{
 		return $this->get($key, true);
 	}
+
+	/**
+	 * Register a service provider to the container.
+	 *
+	 * @param   ServiceProviderInterface $provider
+	 *
+	 * @return  Container  This object for chaining.
+	 */
+	public function registerServiceProvider(ServiceProviderInterface $provider)
+	{
+		$provider->register($this);
+
+		return $this;
+	}
 }
 

--- a/src/Joomla/DI/Container.php
+++ b/src/Joomla/DI/Container.php
@@ -347,6 +347,8 @@ class Container
 	 * @param   ServiceProviderInterface $provider
 	 *
 	 * @return  Container  This object for chaining.
+	 *
+	 * @since   1.0
 	 */
 	public function registerServiceProvider(ServiceProviderInterface $provider)
 	{

--- a/src/Joomla/DI/ServiceProviderInterface.php
+++ b/src/Joomla/DI/ServiceProviderInterface.php
@@ -8,7 +8,21 @@
 
 namespace Joomla\DI;
 
+/**
+ * Defines the interface for a Service Provider.
+ *
+ * @since  1.0
+ */
 interface ServiceProviderInterface
 {
+	/**
+	 * Registers the service provider with a DI container.
+	 *
+	 * @param   Container  $container  The DI container.
+	 *
+	 * @return  Container  Returns itself to support chaining.
+	 *
+	 * @since   1.0
+	 */
 	public function register(Container $container);
 }

--- a/src/Joomla/DI/ServiceProviderInterface.php
+++ b/src/Joomla/DI/ServiceProviderInterface.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Part of the Joomla Framework DI Package
+ *
+ * @copyright  Copyright (C) 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\DI;
+
+interface ServiceProviderInterface
+{
+	public function register(Container $container);
+}

--- a/src/Joomla/DI/Tests/ContainerTest.php
+++ b/src/Joomla/DI/Tests/ContainerTest.php
@@ -735,4 +735,27 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertNotSame($this->fixture->getNewInstance('foo'), $this->fixture->getNewInstance('foo'));
 	}
+
+	/**
+	 * Test registering a service provider. Make sure register get's called.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testRegisterServiceProvider()
+	{
+		$mock = $this->getMock('Joomla\\DI\\ServiceProviderInterface');
+
+		$mock->expects($this->once())
+			->method('register');
+
+		$returned = $this->fixture->registerServiceProvider($mock);
+
+		$this->assertSame(
+			$returned,
+			$this->fixture,
+			'When registering a service provider, the container instance should be returned.'
+		);
+	}
 }


### PR DESCRIPTION
Service Providers allow a nice way to encapsulate setup procedures for services on the Container. This is a sort-of replacement for our historical usage of JFactory.
