### PR TITLE
Fix bug in InputMocker class; add `getArray` mock support

### DIFF
--- a/src/Joomla/Input/Json.php
+++ b/src/Joomla/Input/Json.php
@@ -47,7 +47,15 @@ class Json extends Input
 
 		if (is_null($source))
 		{
-			$this->raw  = file_get_contents('php://input');
+			$this->raw = file_get_contents('php://input');
+
+			// This is a workaround for where php://input has already been read.
+			// See note under php://input on http://php.net/manual/en/wrappers.php.php
+			if (empty($this->raw) && isset($GLOBALS['HTTP_RAW_POST_DATA']))
+			{
+				$this->raw = $GLOBALS['HTTP_RAW_POST_DATA'];
+			}
+
 			$this->data = json_decode($this->raw, true);
 
 			if (!is_array($this->data))

--- a/src/Joomla/Input/README.md
+++ b/src/Joomla/Input/README.md
@@ -323,6 +323,7 @@ class MyTest extends \PHPUnit_Framework_TestCase
 The `createInput` method will return a mock of the `Input\Input` class with the following methods mocked to roughly simulate real behaviour albeit with reduced functionality:
 
 * `get($name [, $default, $fitler])`
+* `getArray([$array, $datasource])`
 * `getInt($name [, $default])`
 * `set($name, $value)`
 
@@ -333,6 +334,7 @@ The `createInputJson` method will return a mock of the `Input\Json` class. It ex
 You can provide customised implementations these methods by creating the following methods in your test class respectively:
 
 * `mockInputGet`
+* `mockInputGetArray`
 * `mockInputGetInt`
 * `mockInputSet`
 * `mockInputGetRaw`

--- a/src/Joomla/Input/Tests/InputMocker.php
+++ b/src/Joomla/Input/Tests/InputMocker.php
@@ -88,6 +88,7 @@ class InputMocker
 			$this->test,
 			array(
 				'get' => array((is_callable(array($this->test, 'mockInputGet')) ? $this->test : $this), 'mockInputGet'),
+				'getArray' => array((is_callable(array($this->test, 'mockInputGetArray')) ? $this->test : $this), 'mockInputGetArray'),
 				'getInt' => array((is_callable(array($this->test, 'mockInputGetInt')) ? $this->test : $this), 'mockInputGetInt'),
 				'set' => array((is_callable(array($this->test, 'mockInputSet')) ? $this->test : $this), 'mockInputSet'),
 			)
@@ -136,6 +137,23 @@ class InputMocker
 	public function mockInputGet($name, $default = null, $filter = 'cmd')
 	{
 		return isset($this->inputs[$name]) ? $this->inputs[$name] : $default;
+	}
+
+	/**
+	 * Callback for the mock getArray method.
+	 *
+	 * @param   array  $vars        Associative array of keys and filter types to apply.
+	 *                              If empty and datasource is null, all the input data will be returned
+	 *                              but filtered using the default case in JFilterInput::clean.
+	 * @param   mixed  $datasource  Array to retrieve data from, or null
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function mockInputGetArray(array $vars = array(), $datasource = null)
+	{
+		return array();
 	}
 
 	/**

--- a/src/Joomla/Input/Tests/InputMocker.php
+++ b/src/Joomla/Input/Tests/InputMocker.php
@@ -111,7 +111,7 @@ class InputMocker
 	{
 		$mockObject = $this->createInput(array('methods' => array('getRaw')));
 
-		Helper::assignMockCallbacks(
+		TestHelper::assignMockCallbacks(
 			$mockObject,
 			$this->test,
 			array(


### PR DESCRIPTION
Fixed up an incorrectly named `TestHelper` reference.
Added the ability to mock the `getArray` method for tests.
Adds an edge-case workaround in `Input\Json` that prevented it from working if `php://input` had already been accessed.
