### PR TITLE
gitignore and rules for /vendor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ composer.lock
 /vendor/autoload.php
 /vendor/composer/
 /vendor/psr/
+/vendor/symfony/
 
 # Test Related Files #
 phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,18 @@
 # IDE & System Related Files #
 .*
 
+
 # Composer files specific to local instances #
 composer.phar
 composer.lock
-/vendor/autoload.php
-/vendor/composer/
-/vendor/psr/
-/vendor/symfony/
+
+# Required composer dependencies
+/vendor/*
+
+# But keep packages shipped with Framework
+!/vendor/phputf8/
+!/vendor/psr/cache/
+
 
 # Test Related Files #
 phpunit.xml


### PR DESCRIPTION
To run unit tests on branch, I run composer to install all dependencies for testing.
Added assets were specified in `.gitignore` but not `symfony/yaml` (see [composer.json](https://github.com/joomla/joomla-framework/blob/staging/composer.json#L12)).

I changed the rules to ignore everything in `/vendor` folder but the packages shipped with the framework (currently `phputf8/` and `psr/cache/`), so this is a change from blacklisting to whitelisting.
