### PR TITLE
 Improved SSL (https) detection in AbstractWebApplication

### DIFF
--- a/src/Joomla/Application/AbstractWebApplication.php
+++ b/src/Joomla/Application/AbstractWebApplication.php
@@ -571,7 +571,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	protected function detectRequestUri()
 	{
 		// First we need to detect the URI scheme.
-		if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+		if ((isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off')) || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https'))
 		{
 			$scheme = 'https://';
 		}

--- a/src/Joomla/Application/AbstractWebApplication.php
+++ b/src/Joomla/Application/AbstractWebApplication.php
@@ -571,7 +571,9 @@ abstract class AbstractWebApplication extends AbstractApplication
 	protected function detectRequestUri()
 	{
 		// First we need to detect the URI scheme.
-		if ((isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off')) || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https'))
+		if ((isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+			|| (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')
+		)
 		{
 			$scheme = 'https://';
 		}

--- a/src/Joomla/Application/Tests/AbstractWebApplicationTest.php
+++ b/src/Joomla/Application/Tests/AbstractWebApplicationTest.php
@@ -63,11 +63,12 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 	public function getDetectRequestUriData()
 	{
 		return array(
-			// HTTPS, PHP_SELF, REQUEST_URI, HTTP_HOST, SCRIPT_NAME, QUERY_STRING, (resulting uri)
-			array(null, '/j/index.php', '/j/index.php?foo=bar', 'joom.la:3', '/j/index.php', '', 'http://joom.la:3/j/index.php?foo=bar'),
-			array('on', '/j/index.php', '/j/index.php?foo=bar', 'joom.la:3', '/j/index.php', '', 'https://joom.la:3/j/index.php?foo=bar'),
-			array(null, '', '', 'joom.la:3', '/j/index.php', '', 'http://joom.la:3/j/index.php'),
-			array(null, '', '', 'joom.la:3', '/j/index.php', 'foo=bar', 'http://joom.la:3/j/index.php?foo=bar'),
+			// HTTPS, HTTP_X_FORWARDED_PROTO, PHP_SELF, REQUEST_URI, HTTP_HOST, SCRIPT_NAME, QUERY_STRING, (resulting uri)
+			array(null, null, '/j/index.php', '/j/index.php?foo=bar', 'joom.la:3', '/j/index.php', '', 'http://joom.la:3/j/index.php?foo=bar'),
+			array('on', null, '/j/index.php', '/j/index.php?foo=bar', 'joom.la:3', '/j/index.php', '', 'https://joom.la:3/j/index.php?foo=bar'),
+			array(null, 'https', '/j/index.php', '/j/index.php?foo=bar', 'joom.la:3', '/j/index.php', '', 'https://joom.la:3/j/index.php?foo=bar'),
+			array(null, null, '', '', 'joom.la:3', '/j/index.php', '', 'http://joom.la:3/j/index.php'),
+			array(null, null, '', '', 'joom.la:3', '/j/index.php', 'foo=bar', 'http://joom.la:3/j/index.php?foo=bar'),
 		);
 	}
 
@@ -588,24 +589,30 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * Tests the Joomla\Application\AbstractWebApplication::detectRequestUri method.
 	 *
-	 * @param   string  $https        @todo
-	 * @param   string  $phpSelf      @todo
-	 * @param   string  $requestUri   @todo
-	 * @param   string  $httpHost     @todo
-	 * @param   string  $scriptName   @todo
-	 * @param   string  $queryString  @todo
-	 * @param   string  $expects      @todo
+	 * @param   string  $https                   @todo
+	 * @param   string  $http_x_forwarded_proto  @todo
+	 * @param   string  $phpSelf                 @todo
+	 * @param   string  $requestUri              @todo
+	 * @param   string  $httpHost                @todo
+	 * @param   string  $scriptName              @todo
+	 * @param   string  $queryString             @todo
+	 * @param   string  $expects                 @todo
 	 *
 	 * @return  void
 	 *
 	 * @dataProvider getDetectRequestUriData
 	 * @since   1.0
 	 */
-	public function testDetectRequestUri($https, $phpSelf, $requestUri, $httpHost, $scriptName, $queryString, $expects)
+	public function testDetectRequestUri($https, $http_x_forwarded_proto, $phpSelf, $requestUri, $httpHost, $scriptName, $queryString, $expects)
 	{
 		if ($https !== null)
 		{
 			$_SERVER['HTTPS'] = $https;
+		}
+
+		if ($http_x_forwarded_proto !== null)
+		{
+			$_SERVER['HTTP_X_FORWARDED_PROTO'] = $http_x_forwarded_proto;
 		}
 
 		$_SERVER['PHP_SELF'] = $phpSelf;


### PR DESCRIPTION
Apparently, when behind load balancer, it terminates the SSL connection and forwards on port 80.
In effect the 
`$_SERVER['HTTPS']` header is not present anymore, but 
`$_SERVER['HTTP_X_FORWARDED_PROTO']` is with value of `'https'`.

Resources:
- Wikipedia: [Common non-standard request headers](http://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Common_non-standard_request_headers) > X-Forwarded-Proto

> a de facto standard for identifying the originating protocol of an HTTP request, since a reverse proxy (load balancer) may communicate with a web server using HTTP even if the request to the reverse proxy is HTTPS
- StackOverflow: [Detecting https requests in php](http://stackoverflow.com/questions/452375/detecting-https-requests-in-php#answer-9031882)
- Wordpress: [Request: modify is_ssl() function to check for HTTP_X_FORWARDED_PROTO](http://wordpress.org/support/topic/request-modify-is_ssl-function-to-check-for-http_x_forwarded_proto)
- Random github issue: [Respect the header HTTP_X_FORWARDED_PROTO](https://github.com/puma/puma/pull/200)

Quick and dirty worakound to set HTTPS header manually in `.htaccess`:

```
<IfModule mod_rewrite.c>
    RewriteEngine On
    RewriteCond %{HTTP:X-FORWARDED-PROTO} ^https$
    RewriteCond %{HTTP:X-SSL-CIPHER} !^$
    RewriteRule ^(.*)$ - [E=HTTPS:on]
</IfModule>
```
