### PR TITLE
Add a global with() method.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         },
         "classmap": [
             "src/Joomla/Compat/JsonSerializable.php"
+        ],
+        "files": [
+            "src/Joomla/PHP/methods.php"
         ]
     },
     "replace": {

--- a/src/Joomla/PHP/Tests/methodsTest.php
+++ b/src/Joomla/PHP/Tests/methodsTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2013 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\PHP\Tests;
+
+/**
+ * Tests for the global PHP methods.
+ *
+ * @since  1.0
+ */
+class methodsTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * Tests the with method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testWith()
+	{
+		$object = with(new \stdClass);
+
+		$this->assertEquals(
+			new \stdClass,
+			$object
+		);
+	}
+}

--- a/src/Joomla/PHP/methods.php
+++ b/src/Joomla/PHP/methods.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Part of the Joomla Framework Package
+ *
+ * @copyright  Copyright (C) 20013 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+if (!function_exists('with'))
+{
+	/**
+	 * Return the given object. Useful for chaining.
+	 *
+	 * This method provides forward compatibility for the PHP 5.4 feature Class member access on instantiation.
+	 * e.g. (new Foo)->bar().
+	 * See: http://php.net/manual/en/migration54.new-features.php
+	 *
+	 * @param   mixed  $object  The object to return.
+	 *
+	 * @since  1.0
+	 *
+	 * @return mixed
+	 */
+	function with($object)
+	{
+		return $object;
+	}
+}


### PR DESCRIPTION
Given the positive feedback on #180, here is a proposal to add a global function.
Uhhh what ? (wtf).... No, please keep on reading ;)

**Benefits**
- Reduce the usage of **local variables**.
- Add **forward compatibility** for the PHP 5.4 feature [Class member access on instantiation](http://php.net/manual/en/migration54.new-features.php).

**Example**:
Plain PHP 5.3:

``` php
$class = new Class;
$result = $class->method();
```

Using the proposed `with()` function:

``` php
$result = with(new Class)->method();
```

Now when switching the minimum requirements to PHP 5.4 you simply change it to:

``` php
$result = (new Class)->method();
```

and remove the whole evil global function from the code base...

I hope, you can see the benefits.

The method will be added to a global file in `src/Joomla/PHP/methods.php` which will be loaded by Composers [files autoload mechanism](http://getcomposer.org/doc/04-schema.md#autoload).

---

**Disclaimer**
This has been stolen from the Laravel framework and I am posting the whole magical function here, hoping that they won't prosecute me for copyright infringement ;)
From [laravel/framework/blob/master/src/Illuminate/Support/helpers.php#L869](https://github.com/laravel/framework/blob/master/src/Illuminate/Support/helpers.php#L944)

``` php
function with($object)
{
    return $object;
}
```

The power of simplicity :)
