### PR TITLE
Make Registry support recursive bindData

### DIFF
--- a/src/Joomla/Registry/README.md
+++ b/src/Joomla/Registry/README.md
@@ -1,6 +1,6 @@
 # The Registry Package
 
-```
+``` php
 use Joomla\Registry\Registry;
 
 $registry = new Registry;
@@ -13,15 +13,72 @@ $value = $registry->get('foo');
 
 ```
 
-## Accessing a Registry as an Array
+## Load config by Registry
 
-The `Registry` class implements `ArrayAccess` so the properties of the registry can be accessed as an array. Consider the following examples:
-
-```
+``` php
 use Joomla\Registry\Registry;
 
 $registry = new Registry;
 
+// Load by string
+$registry->loadString('{"foo" : "bar"}');
+
+$registry->loadString('<root></root>', 'xml');
+
+// Load by object or array
+$registry->loadObject($object);
+$registry->loadaArray($array);
+
+// Load by file
+$registry->loadFile($root . '/config/config.json', 'json');
+```
+
+## Accessing a Registry by getter & setter
+
+### Get value
+
+``` php
+$registry->get('foo');
+
+// Get a non-exists value and return default
+$registry->get('foo', 'default');
+
+// OR
+
+$registry->get('foo') ?: 'default';
+```
+
+### Set value
+
+``` php
+// Set value
+$registry->set('bar', $value);
+
+// Sets a default value if not already assigned.
+$registry->def('bar', $default);
+```
+
+### Accessing children value by path
+
+``` php
+$json = '{
+	"parent" : {
+		"child" : "Foo"
+	}
+}';
+
+$registry = new Registry($json);
+
+$registry->get('parent.child'); // return 'Foo'
+
+$registry->set('parent.child', $value);
+```
+
+## Accessing a Registry as an Array
+
+The `Registry` class implements `ArrayAccess` so the properties of the registry can be accessed as an array. Consider the following examples:
+
+``` php
 // Set a value in the registry.
 $registry['foo'] = 'bar';
 
@@ -34,6 +91,103 @@ if (isset($registry['foo']))
 	echo 'Say bar.';
 }
 ```
+
+## Merge Registry
+
+#### Using load* methods to merge two config files.
+
+``` php
+$json1 = '{
+    "field" : {
+        "keyA" : "valueA",
+        "keyB" : "valueB"
+    }
+}';
+
+$json2 = '{
+    "field" : {
+        "keyB" : "a new valueB"
+    }
+}';
+
+$registry->loadString($json1);
+$registry->loadString($json2);
+```
+
+Output
+
+```
+Array(
+    field => Array(
+        keyA => valueA
+        keyB => a new valueB
+    )
+)
+```
+
+#### Merge another Registry
+
+``` php
+$object1 = '{
+	"foo" : "foo value",
+	"bar" : {
+		"bar1" : "bar value 1",
+		"bar2" : "bar value 2"
+	}
+}';
+
+$object2 = '{
+	"foo" : "foo value",
+	"bar" : {
+		"bar2" : "new bar value 2"
+	}
+}';
+
+$registry1 = new Registry(json_decode($object1));
+$registry2 = new Registry(json_decode($object2));
+
+$registry1->merge($registry2);
+```
+
+If you just want to merge first level, do not hope recursive:
+
+``` php
+$registry1->merge($registry2, false); // Set param 2 to false that Registry will only merge first level
+```
+
+## Dump to file.
+
+``` php
+$registry->toString();
+
+$registry->toString('xml');
+
+$registry->toString('ini');
+```
+
+## Using YAML
+
+Add Symfony YAML component in `composer.json`
+
+``` json
+{
+	"require-dev": {
+		"symfony/yaml": "~2.0"
+	}
+}
+```
+
+Using `yaml` format
+
+``` php
+$registry->loadFile($yamlFile, 'yaml');
+
+$registry->loadString('foo: bar', 'yaml');
+
+// Convert to string
+$registry->toString('yaml');
+```
+
 
 ## Installation via Composer
 

--- a/src/Joomla/Registry/Registry.php
+++ b/src/Joomla/Registry/Registry.php
@@ -494,7 +494,7 @@ class Registry implements \JsonSerializable, \ArrayAccess
 		{
 			if ((is_array($v) && ArrayHelper::isAssociative($v)) || is_object($v))
 			{
-				$parent->$k = new \stdClass;
+				$parent->$k = isset($parent->$k) ? $parent->$k : new \stdClass;
 				$this->bindData($parent->$k, $v);
 			}
 			else

--- a/src/Joomla/Registry/Registry.php
+++ b/src/Joomla/Registry/Registry.php
@@ -308,21 +308,16 @@ class Registry implements \JsonSerializable, \ArrayAccess
 	 */
 	public function merge($source)
 	{
-		if (!$source instanceof Registry)
-		{
-			return false;
-		}
-
-		// Load the variables into the registry's default namespace.
-		foreach ($source->toArray() as $k => $v)
-		{
-			if (($v !== null) && ($v !== ''))
-			{
-				$this->data->$k = $v;
-			}
-		}
-
-		return true;
+	    if (!$source instanceof Registry)
+	    {
+	        return false;
+	    }
+	
+	    $data = $source->toArray();
+	
+	    $this->bindData($this, $data);
+	
+	    return true;
 	}
 
 	/**

--- a/src/Joomla/Registry/Registry.php
+++ b/src/Joomla/Registry/Registry.php
@@ -494,7 +494,11 @@ class Registry implements \JsonSerializable, \ArrayAccess
 		{
 			if ((is_array($v) && ArrayHelper::isAssociative($v)) || is_object($v))
 			{
-				$parent->$k = isset($parent->$k) ? $parent->$k : new \stdClass;
+				if (!isset($parent->$k))
+				{
+				    $parent->$k = new \stdClass;
+				}
+				
 				$this->bindData($parent->$k, $v);
 			}
 			else


### PR DESCRIPTION
This is just a little recommend of making Registry recursive merge a new loading file.
### Before

``` php
$json1 = '{
    "field" : {
        "keyA" : "valueA",
        "keyB" : "valueB"
    }
}';

$json2 = '{
    "field" : {
        "keyB" : "a new valueB"
    }
}';

$registry->loadString($json1);
$registry->loadString($json2);
```

Output

```
Array(
    field => Array(
        keyB => a new valueB
    )
)
```
### After

``` php
$json1 = '{
    "field" : {
        "keyA" : "valueA",
        "keyB" : "valueB"
    }
}';

$json2 = '{
    "field" : {
        "keyB" : "a new valueB"
    }
}';

$registry->loadString($json1);
$registry->loadString($json2);
```

Output

```
Array(
    field => Array(
        keyA => valueA
        keyB => a new valueB
    )
)
```
