### PR TITLE
Add backtrace information to database debug log

### DIFF
--- a/src/Joomla/Database/Mysql/MysqlDriver.php
+++ b/src/Joomla/Database/Mysql/MysqlDriver.php
@@ -268,7 +268,7 @@ class MysqlDriver extends MysqliDriver
 			$this->log(
 				Log\LogLevel::DEBUG,
 				'{sql}',
-				array('sql' => $sql, 'category' => 'databasequery')
+				array('sql' => $sql, 'category' => 'databasequery', 'trace' => debug_backtrace())
 			);
 		}
 

--- a/src/Joomla/Database/Mysqli/MysqliDriver.php
+++ b/src/Joomla/Database/Mysqli/MysqliDriver.php
@@ -510,7 +510,7 @@ class MysqliDriver extends DatabaseDriver
 			$this->log(
 				Log\LogLevel::DEBUG,
 				'{sql}',
-				array('sql' => $sql, 'category' => 'databasequery')
+				array('sql' => $sql, 'category' => 'databasequery', 'trace' => debug_backtrace())
 			);
 		}
 

--- a/src/Joomla/Database/Pdo/PdoDriver.php
+++ b/src/Joomla/Database/Pdo/PdoDriver.php
@@ -392,7 +392,7 @@ abstract class PdoDriver extends DatabaseDriver
 			$this->log(
 				Log\LogLevel::DEBUG,
 				'{sql}',
-				array('sql' => $sql, 'category' => 'databasequery')
+				array('sql' => $sql, 'category' => 'databasequery', 'trace' => debug_backtrace())
 			);
 		}
 

--- a/src/Joomla/Database/Postgresql/PostgresqlDriver.php
+++ b/src/Joomla/Database/Postgresql/PostgresqlDriver.php
@@ -680,7 +680,7 @@ class PostgresqlDriver extends DatabaseDriver
 			$this->log(
 				Log\LogLevel::DEBUG,
 				'{sql}',
-				array('sql' => $sql, 'category' => 'databasequery')
+				array('sql' => $sql, 'category' => 'databasequery', 'trace' => debug_backtrace())
 			);
 		}
 

--- a/src/Joomla/Database/Sqlsrv/SqlsrvDriver.php
+++ b/src/Joomla/Database/Sqlsrv/SqlsrvDriver.php
@@ -593,7 +593,7 @@ class SqlsrvDriver extends DatabaseDriver
 			$this->log(
 				Log\LogLevel::DEBUG,
 				'{sql}',
-				array('sql' => $sql, 'category' => 'databasequery')
+				array('sql' => $sql, 'category' => 'databasequery', 'trace' => debug_backtrace())
 			);
 		}
 


### PR DESCRIPTION
This will pass  the backtrace information to any attached logger when executing a database query in debug mode.

Currently implemented for `Mysql`, `Mysqli`, "`Pdo`", `PostgreSql`, and `SqlSrv` drivers.

An example implementation might render like this:

![issues list 2013-10-03 13-36-10](https://f.cloud.github.com/assets/33978/1264091/ca7cf430-2c5a-11e3-9e95-05bc29abedee.png)
