### PR TITLE
joomla-framework: Implemented Redis Cache Handler

### DIFF
--- a/src/Joomla/Cache/Redis.php
+++ b/src/Joomla/Cache/Redis.php
@@ -83,7 +83,7 @@ class Redis extends Cache
         $value = $this->driver->get($key);
         $item = new Item($key);
 
-        if (is_null($value) == false)
+        if ($value !== false)
         {
             $item->setValue($value);
         }
@@ -174,7 +174,7 @@ class Redis extends Cache
 
         $this->driver = new RedisDriver();
 
-        if (($host == 'localhost' || $this->isIP($host)))
+        if (($host == 'localhost' || filter_var($host, FILTER_VALIDATE_IP)))
         {
             $this->driver->connect('tcp://'. $host.':'.$port, $port);
         }
@@ -182,18 +182,6 @@ class Redis extends Cache
         {
             $this->driver->connect($host, null);
         }
-    }
-
-    /**
-     * Checks is given string is a valid TCP string
-     *
-     * @var string $ip Address to be validated
-     *
-     * @return bool True if given address is valid IP
-     */
-    protected function isIP($ip = '')
-    {
-        return filter_var($ip, FILTER_VALIDATE_IP);
     }
 
 }

--- a/src/Joomla/Cache/Redis.php
+++ b/src/Joomla/Cache/Redis.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Part of the Joomla Framework Cache Package
+ *
+ * @copyright  Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Cache;
+
+use Psr\Cache\CacheItemInterface;
+use \Redis as RedisDriver;
+
+/**
+ * Redis cache driver for the Joomla Framework.
+ *
+ * @since  1.0
+ */
+class Redis extends Cache
+{
+    /**
+     * Default hostname of redis server
+     */
+    const REDIS_HOST = '127.0.0.1';
+
+    /**
+     * Default port of redis server
+     */
+    const REDIS_PORT = 6379;
+
+    /**
+     * @var    \Redis  The redis driver.
+     * @since  1.0
+     */
+    private $driver;
+
+
+    /**
+     * Constructor.
+     *
+     * @param   mixed  $options  An options array, or an object that implements \ArrayAccess
+     *
+     * @since   1.0
+     * @throws  \RuntimeException
+     */
+    public function __construct($options = array())
+    {
+        parent::__construct($options);
+
+        if (!extension_loaded('redis') || !class_exists('\Redis'))
+        {
+            throw new \RuntimeException('Redis not supported.');
+        }
+    }
+
+    /**
+     * This will wipe out the entire cache's keys
+     *
+     * @return  boolean  The result of the clear operation.
+     *
+     * @since   1.0
+     */
+    public function clear()
+    {
+        $this->connect();
+
+        return $this->driver->flushall();
+    }
+
+    /**
+     * Method to get a storage entry value from a key.
+     *
+     * @param   string  $key  The storage entry identifier.
+     *
+     * @return  CacheItemInterface
+     *
+     * @since   1.0
+     */
+    public function get($key)
+    {
+        $this->connect();
+
+        $value = $this->driver->get($key);
+        $item = new Item($key);
+
+        if (is_null($value) == false)
+        {
+            $item->setValue($value);
+        }
+
+        return $item;
+    }
+
+    /**
+     * Method to remove a storage entry for a key.
+     *
+     * @param   string  $key  The storage entry identifier.
+     *
+     * @return  boolean
+     *
+     * @since   1.0
+     */
+    public function remove($key)
+    {
+        $this->connect();
+
+        $result = (bool) $this->driver->del($key);
+
+        return $result;
+    }
+
+
+    /**
+     * Method to set a value for a storage entry.
+     *
+     * @param   string   $key    The storage entry identifier.
+     * @param   mixed    $value  The data to be stored.
+     * @param   integer  $ttl    The number of seconds before the stored data expires.
+     *
+     * @return  boolean
+     *
+     * @since   1.0
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        $this->connect();
+
+        if (!$this->driver->set($key, $value))
+            return false;
+
+        if ($ttl)
+        {
+            if (!$this->driver->expire($key, $ttl))
+                return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Method to determine whether a storage entry has been set for a key.
+     *
+     * @param   string  $key  The storage entry identifier.
+     *
+     * @return  boolean
+     *
+     * @since   1.0
+     */
+    protected function exists($key)
+    {
+        $this->connect();
+
+        return $this->driver->exists($key);
+    }
+
+
+    /**
+     * Connect to the Redis servers if the connection does not already exist.
+     *
+     * @return  void
+     *
+     * @since   1.0
+     */
+    private function connect()
+    {
+        // We want to only create the driver once.
+        if (isset($this->driver))
+        {
+            return;
+        }
+
+        $host   = isset($this->options['redis.host'])? $this->options['redis.host'] : self::REDIS_HOST;
+        $port   = isset($this->options['redis.port'])? $this->options['redis.port'] : self::REDIS_PORT;
+
+        $this->driver = new RedisDriver();
+
+        if (($host == 'localhost' || $this->isIP($host)))
+        {
+            $this->driver->connect('tcp://'. $host.':'.$port, $port);
+        }
+        else
+        {
+            $this->driver->connect($host, null);
+        }
+    }
+
+    /**
+     * Checks is given string is a valid TCP string
+     *
+     * @var string $ip Address to be validated
+     *
+     * @return bool True if given address is valid IP
+     */
+    protected function isIP($ip = '')
+    {
+        return filter_var($ip, FILTER_VALIDATE_IP);
+    }
+
+}

--- a/src/Joomla/Cache/Redis.php
+++ b/src/Joomla/Cache/Redis.php
@@ -9,7 +9,7 @@
 namespace Joomla\Cache;
 
 use Psr\Cache\CacheItemInterface;
-use \Redis as RedisDriver;
+use Redis as RedisDriver;
 
 /**
  * Redis cache driver for the Joomla Framework.
@@ -45,12 +45,12 @@ class Redis extends Cache
      */
     public function __construct($options = array())
     {
-        parent::__construct($options);
-
         if (!extension_loaded('redis') || !class_exists('\Redis'))
         {
             throw new \RuntimeException('Redis not supported.');
         }
+
+        parent::__construct($options);
     }
 
     /**
@@ -146,7 +146,7 @@ class Redis extends Cache
      *
      * @since   1.0
      */
-    protected function exists($key)
+    public function exists($key)
     {
         $this->connect();
 

--- a/src/Joomla/Cache/Tests/RedisTest.php
+++ b/src/Joomla/Cache/Tests/RedisTest.php
@@ -122,7 +122,7 @@ class RedisTest extends \PHPUnit_Framework_TestCase
         }
         catch (\Exception $e)
         {
-            $this->markTestSkipped();
+            $this->markTestSkipped($e->getMessage());
         }
     }
 }

--- a/src/Joomla/Cache/Tests/RedisTest.php
+++ b/src/Joomla/Cache/Tests/RedisTest.php
@@ -122,6 +122,67 @@ class RedisTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->instance->get('foo')->isHit(), 'Item should have been removed');
     }
 
+
+    /**
+     * Tests the Joomla\Cache\Redis::getMultiple method.
+     *
+     * @return  void
+     *
+     * @covers  Joomla\Cache\Redis::getMultiple
+     * @since   1.0
+     */
+    public function testGetMultiple()
+    {
+        $this->instance->set('foo', 'bar');
+        $this->instance->set('boo', 'bar');
+
+        $fooResult = $this->instance->getMultiple(array('foo', 'boo'));
+
+        $this->assertArrayHasKey('foo', $fooResult, 'Missing array key');
+        $this->assertArrayHasKey('boo', $fooResult, 'Missing array key');
+        $this->assertInstanceOf('Joomla\Cache\Item', $fooResult['foo'], 'Expected instance of Joomla\Cache\Item');
+        $this->assertInstanceOf('Joomla\Cache\Item', $fooResult['boo'], 'Expected instance of Joomla\Cache\Item');
+        $this->assertTrue($fooResult['foo']->isHit(), 'Item should be returned from cache');
+        $this->assertTrue($fooResult['boo']->isHit(), 'Item should be returned from cache');
+    }
+
+    /**
+     * Tests the Joomla\Cache\Redis::setMultiple method.
+     *
+     * @return  void
+     *
+     * @covers  Joomla\Cache\Redis::setMultiple
+     * @since   1.0
+     */
+    public function testSetMultiple()
+    {
+        $data = array('foo' => 'bar', 'boo' => 'bar');
+
+        $this->instance->setMultiple($data);
+
+        $this->assertEquals('bar', $this->instance->get('foo')->getValue(), 'Item should be cached');
+        $this->assertEquals('bar', $this->instance->get('boo')->getValue(), 'Item should be cached');
+    }
+
+    /**
+     * Tests the Joomla\Cache\Redis::removeMultiple method.
+     *
+     * @return  void
+     *
+     * @covers  Joomla\Cache\Redis::removeMultiple
+     * @since   1.0
+     */
+    public function removeMultiple()
+    {
+        $this->instance->set('foo', 'bar');
+        $this->instance->set('boo', 'bar');
+
+        $this->instance->removeMultiple(array('foo', 'bar'));
+
+        $this->assertFalse($this->instance->get('foo')->isHit(), 'Item should have been removed');
+        $this->assertFalse($this->instance->get('boo')->isHit(), 'Item should have been removed');
+    }
+
     /**
      * Setup the tests.
      *

--- a/src/Joomla/Cache/Tests/RedisTest.php
+++ b/src/Joomla/Cache/Tests/RedisTest.php
@@ -41,6 +41,37 @@ class RedisTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests the Joomla\Cache\Redis::get and Joomla\Cache\Redis::set methods.
+     *
+     * @return  void
+     *
+     * @covers  Joomla\Cache\Redis::get
+     * @covers  Joomla\Cache\Redis::set
+     * @since   1.0
+     */
+    public function testGetAndSet()
+    {
+        $this->assertTrue($this->instance->set('foo', 'bar'), 'Should store the data properly');
+        $this->assertEquals('bar', $this->instance->get('foo')->getValue(), 'Checking get');
+    }
+
+    /**
+     * Tests the Joomla\Cache\Redis::get and Joomla\Cache\Redis::set methods with timeout
+     *
+     * @return  void
+     *
+     * @covers  Joomla\Cache\Redis::get
+     * @covers  Joomla\Cache\Redis::set
+     * @since   1.0
+     */
+    public function testGetAndSetWithTimeout()
+    {
+        $this->assertTrue($this->instance->set('foo', 'bar', 1), 'Should store the data properly');
+        sleep(2);
+        $this->assertFalse($this->instance->get('foo')->isHit(), 'Checks expired get.');
+    }
+
+    /**
      * Tests the Joomla\Cache\Redis::clear method.
      *
      * @return  void
@@ -50,7 +81,13 @@ class RedisTest extends \PHPUnit_Framework_TestCase
      */
     public function testClear()
     {
-        $this->markTestIncomplete();
+        $this->instance->set('foo', 'bar');
+        $this->instance->set('boo', 'car');
+
+        $this->instance->clear();
+
+        $this->assertFalse($this->instance->get('foo')->isHit(), 'Item should have been removed');
+        $this->assertFalse($this->instance->get('goo')->isHit(), 'Item should have been removed');
     }
 
     /**
@@ -63,20 +100,9 @@ class RedisTest extends \PHPUnit_Framework_TestCase
      */
     public function testExists()
     {
-        $this->markTestIncomplete();
-    }
-
-    /**
-     * Tests the Joomla\Cache\Redis::get method.
-     *
-     * @return  void
-     *
-     * @covers  Joomla\Cache\Redis::get
-     * @since   1.0
-     */
-    public function testGet()
-    {
-        $this->markTestIncomplete();
+        $this->assertFalse($this->instance->exists('foo'), 'Item should not exist');
+        $this->instance->set('foo', 'bar');
+        $this->assertTrue($this->instance->exists('foo'), 'Item should exist');
     }
 
     /**
@@ -87,22 +113,13 @@ class RedisTest extends \PHPUnit_Framework_TestCase
      * @covers  Joomla\Cache\Redis::remove
      * @since   1.0
      */
+
     public function testRemove()
     {
-        $this->markTestIncomplete();
-    }
-
-    /**
-     * Tests the Joomla\Cache\Redis::set method.
-     *
-     * @return  void
-     *
-     * @covers  Joomla\Cache\Redis::set
-     * @since   1.0
-     */
-    public function testSet()
-    {
-        $this->markTestIncomplete();
+        $this->instance->set('foo', 'bar');
+        $this->assertTrue($this->instance->get('foo')->isHit(), 'Item should exist');
+        $this->instance->remove('foo');
+        $this->assertFalse($this->instance->get('foo')->isHit(), 'Item should have been removed');
     }
 
     /**
@@ -123,6 +140,36 @@ class RedisTest extends \PHPUnit_Framework_TestCase
         catch (\Exception $e)
         {
             $this->markTestSkipped($e->getMessage());
+        }
+    }
+
+    /**
+     * Flush all data before each test
+     *
+     * @return  void
+     *
+     * @since   1.0
+     */
+    protected function assertPreConditions()
+    {
+        if ($this->instance)
+        {
+            $this->instance->clear();
+        }
+    }
+
+    /**
+     * Teardown the test.
+     *
+     * @return  void
+     *
+     * @since   1.0
+     */
+    protected function tearDown()
+    {
+        if ($this->instance)
+        {
+            $this->instance->clear();
         }
     }
 }

--- a/src/Joomla/Cache/Tests/RedisTest.php
+++ b/src/Joomla/Cache/Tests/RedisTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Cache\Tests;
+
+use Joomla\Cache;
+
+/**
+ * Tests for the Joomla\Cache\Redis class.
+ *
+ * @since  1.0
+ */
+class RedisTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var    Cache\Redis
+     * @since  1.0
+     */
+    private $instance;
+
+    /**
+     * Tests for the correct Psr\Cache return values.
+     *
+     * @return  void
+     *
+     * @coversNothing
+     * @since   1.0
+     */
+    public function testPsrCache()
+    {
+        $this->assertInternalType('boolean', $this->instance->clear(), 'Checking clear.');
+        $this->assertInstanceOf('\Psr\Cache\CacheItemInterface', $this->instance->get('foo'), 'Checking get.');
+        $this->assertInternalType('array', $this->instance->getMultiple(array('foo')), 'Checking getMultiple.');
+        $this->assertInternalType('boolean', $this->instance->remove('foo'), 'Checking remove.');
+        $this->assertInternalType('array', $this->instance->removeMultiple(array('foo')), 'Checking removeMultiple.');
+        $this->assertInternalType('boolean', $this->instance->set('for', 'bar'), 'Checking set.');
+        $this->assertInternalType('boolean', $this->instance->setMultiple(array('foo' => 'bar')), 'Checking setMultiple.');
+    }
+
+    /**
+     * Tests the Joomla\Cache\Redis::clear method.
+     *
+     * @return  void
+     *
+     * @covers  Joomla\Cache\Redis::clear
+     * @since   1.0
+     */
+    public function testClear()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * Tests the Joomla\Cache\Redis::exists method.
+     *
+     * @return  void
+     *
+     * @covers  Joomla\Cache\Redis::exists
+     * @since   1.0
+     */
+    public function testExists()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * Tests the Joomla\Cache\Redis::get method.
+     *
+     * @return  void
+     *
+     * @covers  Joomla\Cache\Redis::get
+     * @since   1.0
+     */
+    public function testGet()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * Tests the Joomla\Cache\Redis::remove method.
+     *
+     * @return  void
+     *
+     * @covers  Joomla\Cache\Redis::remove
+     * @since   1.0
+     */
+    public function testRemove()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * Tests the Joomla\Cache\Redis::set method.
+     *
+     * @return  void
+     *
+     * @covers  Joomla\Cache\Redis::set
+     * @since   1.0
+     */
+    public function testSet()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * Setup the tests.
+     *
+     * @return  void
+     *
+     * @since   1.0
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        try
+        {
+            $this->instance = new Cache\Redis;
+        }
+        catch (\Exception $e)
+        {
+            $this->markTestSkipped();
+        }
+    }
+}


### PR DESCRIPTION
Greetings!

I have implemented a cache handler for Redis storage. It uses PHP Redis extension.

It accepts 2 Registry configuration options for Redis Host IP/Socket and Redis Port as follows:
redis.host // default: 127.0.0.1
redis.port // default: 6379

Both can be skipped or unix socket path can be provided instead of host.

Only had a chance to test on Windows. But I'm pretty sure it should be fine on *nix based oses.

References:
Predis: https://github.com/nrk/predis
Joomla CMS PR: https://github.com/joomla/joomla-cms/pull/2078
