### PR TITLE
Remove Factory usage from the Session package

### DIFF
--- a/src/Joomla/Application/AbstractWebApplication.php
+++ b/src/Joomla/Application/AbstractWebApplication.php
@@ -758,4 +758,55 @@ abstract class AbstractWebApplication extends AbstractApplication
 			$this->set('uri.media.path', $this->get('uri.base.path') . 'media/');
 		}
 	}
+
+	/**
+	 * Checks for a form token in the request.
+	 *
+	 * Use in conjunction with getFormToken.
+	 *
+	 * @param   string  $method  The request method in which to look for the token key.
+	 *
+	 * @return  boolean  True if found and valid, false otherwise.
+	 *
+	 * @since   1.0
+	 */
+	public function checkToken($method = 'post')
+	{
+		$token = $this->getFormToken();
+
+		if (!$this->input->$method->get($token, '', 'alnum'))
+		{
+			if ($this->session->isNew())
+			{
+				// Redirect to login screen.
+				$this->redirect('index.php');
+				$this->close();
+			}
+			else
+			{
+				return false;
+			}
+		}
+		else
+		{
+			return true;
+		}
+	}
+
+	/**
+	 * Method to determine a hash for anti-spoofing variable names
+	 *
+	 * @param   boolean  $forceNew  If true, force a new token to be created
+	 *
+	 * @return  string  Hashed var name
+	 *
+	 * @since   1.0
+	 */
+	public function getFormToken($forceNew = false)
+	{
+		// @todo we need the user id somehow here
+		$userId  = 0;
+
+		return md5($this->get('secret') . $userId . $this->session->getToken($forceNew));
+	}
 }

--- a/src/Joomla/Application/Tests/AbstractWebApplicationTest.php
+++ b/src/Joomla/Application/Tests/AbstractWebApplicationTest.php
@@ -1270,6 +1270,27 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Test getFormToken
+	 *
+	 * @covers  JSession::getFormToken
+	 *
+	 * @return void
+	 */
+	public function testGetFormToken()
+	{
+		$mockSession = $this->getMock('Joomla\\Session\\Session');
+
+		$this->instance->setSession($mockSession);
+		$this->instance->set('secret', 'abc');
+		$expected = md5('abc' . 0 . $this->instance->getSession()->getToken());
+		$this->assertEquals(
+			$expected,
+			$this->instance->getFormToken(),
+			'Form token should be calculated as above.'
+		);
+	}
+
+	/**
 	 * Setup for testing.
 	 *
 	 * @return  void

--- a/src/Joomla/Application/Tests/AbstractWebApplicationTest.php
+++ b/src/Joomla/Application/Tests/AbstractWebApplicationTest.php
@@ -1272,7 +1272,7 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * Test getFormToken
 	 *
-	 * @covers  JSession::getFormToken
+	 * @covers  Joomla\Application\AbstractWebApplication::getFormToken
 	 *
 	 * @return void
 	 */

--- a/src/Joomla/Session/Session.php
+++ b/src/Joomla/Session/Session.php
@@ -73,6 +73,22 @@ class Session implements \IteratorAggregate
 	protected $force_ssl = false;
 
 	/**
+	 * The domain to use when setting cookies.
+	 *
+	 * @var    mixed
+	 * @since  1.0
+	 */
+	protected $cookie_domain;
+
+	/**
+	 * The path to use when setting cookies.
+	 *
+	 * @var    mixed
+	 * @since  1.0
+	 */
+	protected $cookie_path;
+
+	/**
 	 * Session instances container.
 	 *
 	 * @var    Session
@@ -682,10 +698,7 @@ class Session implements \IteratorAggregate
 		 */
 		if (isset($_COOKIE[session_name()]))
 		{
-			$config = Factory::getConfig();
-			$cookie_domain = $config->get('cookie_domain', '');
-			$cookie_path = $config->get('cookie_path', '/');
-			setcookie(session_name(), '', time() - 42000, $cookie_path, $cookie_domain);
+			setcookie(session_name(), '', time() - 42000, $this->cookie_path, $this->cookie_domain);
 		}
 
 		session_unset();
@@ -801,16 +814,14 @@ class Session implements \IteratorAggregate
 			$cookie['secure'] = true;
 		}
 
-		$config = Factory::getConfig();
-
-		if ($config->get('cookie_domain', '') != '')
+		if ($this->cookie_domain)
 		{
-			$cookie['domain'] = $config->get('cookie_domain');
+			$cookie['domain'] = $this->cookie_domain;
 		}
 
-		if ($config->get('cookie_path', '') != '')
+		if ($this->cookie_path)
 		{
-			$cookie['path'] = $config->get('cookie_path');
+			$cookie['path'] = $this->cookie_path;
 		}
 
 		session_set_cookie_params($cookie['lifetime'], $cookie['path'], $cookie['domain'], $cookie['secure'], true);
@@ -919,6 +930,16 @@ class Session implements \IteratorAggregate
 		if (isset($options['force_ssl']))
 		{
 			$this->force_ssl = (bool) $options['force_ssl'];
+		}
+
+		if (isset($options['cookie_domain']))
+		{
+			$this->cookie_domain = $options['cookie_domain'];
+		}
+
+		if (isset($options['cookie_path']))
+		{
+			$this->cookie_path = $options['cookie_path'];
 		}
 
 		// Sync the session maxlifetime

--- a/src/Joomla/Session/Session.php
+++ b/src/Joomla/Session/Session.php
@@ -10,7 +10,6 @@ namespace Joomla\Session;
 
 use Joomla\Event\Dispatcher;
 use Joomla\Input\Input;
-use Joomla\Factory;
 
 /**
  * Class for managing HTTP sessions
@@ -276,26 +275,6 @@ class Session implements \IteratorAggregate
 	}
 
 	/**
-	 * Method to determine a hash for anti-spoofing variable names
-	 *
-	 * @param   boolean  $forceNew  If true, force a new token to be created
-	 *
-	 * @return  string  Hashed var name
-	 *
-	 * @since   1.0
-	 */
-	public static function getFormToken($forceNew = false)
-	{
-		// @todo we need the user id somehow here
-		$userId  = 0;
-		$session = Factory::getSession();
-
-		$hash = md5(Factory::getApplication()->get('secret') . $userId . $session->getToken($forceNew));
-
-		return $hash;
-	}
-
-	/**
 	 * Retrieve an external iterator.
 	 *
 	 * @return  \ArrayIterator  Return an ArrayIterator of $_SESSION.
@@ -305,43 +284,6 @@ class Session implements \IteratorAggregate
 	public function getIterator()
 	{
 		return new \ArrayIterator($_SESSION);
-	}
-
-	/**
-	 * Checks for a form token in the request.
-	 *
-	 * Use in conjunction with Joomla\Session\Session::getFormToken.
-	 *
-	 * @param   string  $method  The request method in which to look for the token key.
-	 *
-	 * @return  boolean  True if found and valid, false otherwise.
-	 *
-	 * @since   1.0
-	 */
-	public static function checkToken($method = 'post')
-	{
-		$token = self::getFormToken();
-		$app = Factory::getApplication();
-
-		if (!$app->input->$method->get($token, '', 'alnum'))
-		{
-			$session = Factory::getSession();
-
-			if ($session->isNew())
-			{
-				// Redirect to login screen.
-				$app->redirect('index.php');
-				$app->close();
-			}
-			else
-			{
-				return false;
-			}
-		}
-		else
-		{
-			return true;
-		}
 	}
 
 	/**

--- a/src/Joomla/Session/Storage/Apc.php
+++ b/src/Joomla/Session/Storage/Apc.php
@@ -9,7 +9,6 @@
 namespace Joomla\Session\Storage;
 
 use Joomla\Session\Storage;
-use RuntimeException;
 
 /**
  * APC session storage handler for PHP
@@ -25,13 +24,13 @@ class Apc extends Storage
 	 * @param   array  $options  Optional parameters
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function __construct($options = array())
 	{
 		if (!self::isSupported())
 		{
-			throw new RuntimeException('APC Extension is not available', 404);
+			throw new \RuntimeException('APC Extension is not available', 404);
 		}
 
 		parent::__construct($options);

--- a/src/Joomla/Session/Storage/Memcache.php
+++ b/src/Joomla/Session/Storage/Memcache.php
@@ -9,8 +9,6 @@
 namespace Joomla\Session\Storage;
 
 use Joomla\Session\Storage;
-use Joomla\Factory;
-use RuntimeException;
 
 /**
  * Memcache session storage handler for PHP
@@ -25,25 +23,23 @@ class Memcache extends Storage
 	 * @param   array  $options  Optional parameters.
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function __construct($options = array())
 	{
 		if (!self::isSupported())
 		{
-			throw new RuntimeException('Memcache Extension is not available', 404);
+			throw new \RuntimeException('Memcache Extension is not available', 404);
 		}
 
 		parent::__construct($options);
-
-		$config = Factory::getConfig();
 
 		// This will be an array of loveliness
 		// @todo: multiple servers
 		$this->_servers = array(
 			array(
-				'host' => $config->get('memcache_server_host', 'localhost'),
-				'port' => $config->get('memcache_server_port', 11211)
+				'host' => isset($options['memcache_server_host']) ? $options['memcache_server_host'] : 'localhost',
+				'port' => isset($options['memcache_server_port']) ? $options['memcache_server_port'] : 11211
 			)
 		);
 	}
@@ -57,7 +53,7 @@ class Memcache extends Storage
 	 */
 	public function register()
 	{
-		ini_set('session.save_path', $this->_servers['host'] . ':' . $this->_servers['port']);
+		ini_set('session.save_path', $this->_servers[0]['host'] . ':' . $this->_servers[0]['port']);
 		ini_set('session.save_handler', 'memcache');
 	}
 

--- a/src/Joomla/Session/Storage/Memcached.php
+++ b/src/Joomla/Session/Storage/Memcached.php
@@ -9,8 +9,6 @@
 namespace Joomla\Session\Storage;
 
 use Joomla\Session\Storage;
-use Joomla\Factory;
-use RuntimeException;
 
 /**
  * Memcached session storage handler for PHP
@@ -25,25 +23,23 @@ class Memcached extends Storage
 	 * @param   array  $options  Optional parameters.
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function __construct($options = array())
 	{
 		if (!self::isSupported())
 		{
-			throw new RuntimeException('Memcached Extension is not available', 404);
+			throw new \RuntimeException('Memcached Extension is not available', 404);
 		}
 
 		parent::__construct($options);
-
-		$config = Factory::getConfig();
 
 		// This will be an array of loveliness
 		// @todo: multiple servers
 		$this->_servers = array(
 			array(
-				'host' => $config->get('memcache_server_host', 'localhost'),
-				'port' => $config->get('memcache_server_port', 11211)
+				'host' => isset($options['memcache_server_host']) ? $options['memcache_server_host'] : 'localhost',
+				'port' => isset($options['memcache_server_port']) ? $options['memcache_server_port'] : 11211
 			)
 		);
 	}
@@ -57,7 +53,7 @@ class Memcached extends Storage
 	 */
 	public function register()
 	{
-		ini_set('session.save_path', $this->_servers['host'] . ':' . $this->_servers['port']);
+		ini_set('session.save_path', $this->_servers[0]['host'] . ':' . $this->_servers[0]['port']);
 		ini_set('session.save_handler', 'memcached');
 	}
 

--- a/src/Joomla/Session/Storage/Wincache.php
+++ b/src/Joomla/Session/Storage/Wincache.php
@@ -9,7 +9,6 @@
 namespace Joomla\Session\Storage;
 
 use Joomla\Session\Storage;
-use RuntimeException;
 
 /**
  * WINCACHE session storage handler for PHP
@@ -24,13 +23,13 @@ class Wincache extends Storage
 	 * @param   array  $options  Optional parameters.
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function __construct($options = array())
 	{
 		if (!self::isSupported())
 		{
-			throw new RuntimeException('Wincache Extension is not available', 404);
+			throw new \RuntimeException('Wincache Extension is not available', 404);
 		}
 
 		parent::__construct($options);

--- a/src/Joomla/Session/Storage/Xcache.php
+++ b/src/Joomla/Session/Storage/Xcache.php
@@ -9,7 +9,6 @@
 namespace Joomla\Session\Storage;
 
 use Joomla\Session\Storage;
-use RuntimeException;
 
 /**
  * XCache session storage handler
@@ -24,13 +23,13 @@ class Xcache extends Storage
 	 * @param   array  $options  Optional parameters.
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function __construct($options = array())
 	{
 		if (!self::isSupported())
 		{
-			throw new RuntimeException('XCache Extension is not available', 404);
+			throw new \RuntimeException('XCache Extension is not available', 404);
 		}
 
 		parent::__construct($options);

--- a/src/Joomla/Session/_Tests/JSessionTest.php
+++ b/src/Joomla/Session/_Tests/JSessionTest.php
@@ -183,26 +183,6 @@ class JSessionTest extends TestCase
 	}
 
 	/**
-	 * Test getFormToken
-	 *
-	 * @covers  JSession::getFormToken
-	 *
-	 * @return void
-	 */
-	public function testGetFormToken()
-	{
-		JFactory::$application = $this->getMock('JInputCookie', array('set', 'get'));
-		JFactory::$application->expects($this->once())
-			->method('get')
-			->with($this->equalTo('secret'))
-			->will($this->returnValue('abc'));
-
-		$this->object->set('secret', 'abc');
-		$expected = md5('abc' . 0 . $this->object->getToken(false));
-		$this->assertEquals($expected, $this->object->getFormToken(), 'Form token should be calculated as above.');
-	}
-
-	/**
 	 * Test getName
 	 *
 	 * @covers  JSession::getName

--- a/src/Joomla/Session/composer.json
+++ b/src/Joomla/Session/composer.json
@@ -9,6 +9,9 @@
         "php": ">=5.3.10",
         "joomla/filter": "1.0-beta2"
     },
+    "suggest": {
+        "joomla/database": "Install joomla/database if you want to use Database session storage."
+    },
     "target-dir": "Joomla/Session",
     "autoload": {
     	"psr-0": {


### PR DESCRIPTION
This PR removes all usage of the global `Factory` class from the `Session` package. 

Specifically, it:
- Moves configuration for Storage Drivers into the constructor
- Requires the injection of a `db` parameter when using the Database Storage Driver.
- Moves `getFormToken` and `checkToken` into `AbstractWebApplication`, including the tests.
