### PR TITLE
Make Oauth Client class constructors have mandatory parameters.

### DIFF
--- a/src/Joomla/Facebook/OAuth.php
+++ b/src/Joomla/Facebook/OAuth.php
@@ -22,7 +22,7 @@ use Joomla\Input\Input;
 class OAuth extends Client
 {
 	/**
-	 * @var Joomla\Registry\Registry Options for the OAuth object.
+	 * @var \Joomla\Registry\Registry Options for the OAuth object.
 	 * @since 1.0
 	 */
 	protected $options;
@@ -37,9 +37,9 @@ class OAuth extends Client
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options = null, Http $client = null, Input $input = null, WebInspector $application = null)
+	public function __construct(Registry $options, Http $client, Input $input, WebInspector $application)
 	{
-		$this->options = isset($options) ? $options : new Registry;
+		$this->options = $options;
 
 		// Setup the authentication and token urls if not already set.
 		$this->options->def('authurl', 'http://www.facebook.com/dialog/oauth');

--- a/src/Joomla/Google/Auth/OAuth2.php
+++ b/src/Joomla/Google/Auth/OAuth2.php
@@ -9,7 +9,7 @@
 namespace Joomla\Google\Auth;
 
 use Joomla\Google\Auth;
-use Joomla\OAuth2\Client;
+use Joomla\Oauth2\Client;
 use Joomla\Registry\Registry;
 
 /**
@@ -33,10 +33,10 @@ class OAuth2 extends Auth
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options = null, Client $client = null)
+	public function __construct(Registry $options, Client $client)
 	{
-		$this->options = isset($options) ? $options : new Registry;
-		$this->client = isset($client) ? $client : new Client($this->options);
+		$this->options = $options;
+		$this->client = $client;
 	}
 
 	/**

--- a/src/Joomla/Google/Tests/JGoogleAuthOauth2Test.php
+++ b/src/Joomla/Google/Tests/JGoogleAuthOauth2Test.php
@@ -20,32 +20,32 @@ use Joomla\Test\WebInspector;
 class JGoogleAuthOauth2Test extends \PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    Registry  Options for the Client object.
+	 * @var  Registry  Options for the Client object.
 	 */
 	protected $options;
 
 	/**
-	 * @var    JHttp  Mock client object.
+	 * @var  object  Mock client object.
 	 */
 	protected $http;
 
 	/**
-	 * @var    Input  The input object to use in retrieving GET/POST data.
+	 * @var  Input  The input object to use in retrieving GET/POST data.
 	 */
 	protected $input;
 
 	/**
-	 * @var    Client  The OAuth client for sending requests to Google.
+	 * @var  Client  The OAuth client for sending requests to Google.
 	 */
 	protected $oauth;
 
 	/**
-	 * @var    JApplicationWeb  The application object to send HTTP headers for redirects.
+	 * @var  WebInspector  The application object to send HTTP headers for redirects.
 	 */
 	protected $application;
 
 	/**
-	 * @var    OAuth2  Object under test.
+	 * @var  OAuth2  Object under test.
 	 */
 	protected $object;
 

--- a/src/Joomla/Linkedin/OAuth.php
+++ b/src/Joomla/Linkedin/OAuth.php
@@ -14,7 +14,6 @@ use Joomla\Http\Http;
 use Joomla\Http\Response;
 use Joomla\Input\Input;
 use Joomla\Application\AbstractWebApplication;
-use \DomainException;
 
 /**
  * Joomla Framework class for generating Linkedin API access token.
@@ -39,9 +38,9 @@ class OAuth extends Client
 	 *
 	 * @since 1.0
 	 */
-	public function __construct(Registry $options = null, Http $client = null, Input $input = null, AbstractWebApplication $application = null)
+	public function __construct(Registry $options, Http $client, Input $input, AbstractWebApplication $application)
 	{
-		$this->options = isset($options) ? $options : new Registry;
+		$this->options = $options;
 
 		$this->options->def('accessTokenURL', 'https://www.linkedin.com/uas/oauth/accessToken');
 		$this->options->def('authenticateURL', 'https://www.linkedin.com/uas/oauth/authenticate');
@@ -96,7 +95,7 @@ class OAuth extends Client
 	 * @return  void
 	 *
 	 * @since  1.0
-	 * @throws DomainException
+	 * @throws \DomainException
 	 */
 	public function validateResponse($url, $response)
 	{
@@ -109,11 +108,11 @@ class OAuth extends Client
 		{
 			if ($error = json_decode($response->body))
 			{
-				throw new DomainException('Error code ' . $error->errorCode . ' received with message: ' . $error->message . '.');
+				throw new \DomainException('Error code ' . $error->errorCode . ' received with message: ' . $error->message . '.');
 			}
 			else
 			{
-				throw new DomainException($response->body);
+				throw new \DomainException($response->body);
 			}
 		}
 	}

--- a/src/Joomla/Oauth1/Client.php
+++ b/src/Joomla/Oauth1/Client.php
@@ -12,8 +12,6 @@ use Joomla\Registry\Registry;
 use Joomla\Http\Http;
 use Joomla\Input\Input;
 use Joomla\Application\AbstractWebApplication;
-use Joomla\Factory;
-use \DomainException;
 
 /**
  * Joomla Framework class for interacting with an OAuth 1.0 and 1.0a server.
@@ -69,14 +67,13 @@ abstract class Client
 	 *
 	 * @since 1.0
 	 */
-	public function __construct(Registry $options = null, Http $client = null, Input $input = null, AbstractWebApplication $application = null,
-		$version = null)
+	public function __construct(Registry $options, Http $client, Input $input, AbstractWebApplication $application, $version = '1.0a')
 	{
-		$this->options = isset($options) ? $options : new Registry;
-		$this->client = isset($client) ? $client : new Http($this->options);
-		$this->application = isset($application) ? $application : Factory::$application;
-		$this->input = isset($input) ? $input : $this->application->input;
-		$this->version = isset($version) ? $version : '1.0a';
+		$this->options = $options;
+		$this->client = $client;
+		$this->input = $input;
+		$this->application = $application;
+		$this->version = $version;
 	}
 
 	/**
@@ -127,7 +124,7 @@ abstract class Client
 		// Callback
 		else
 		{
-			$session = Factory::getSession();
+			$session = $this->application->getSession();
 
 			// Get token form session.
 			$this->token = array('key' => $session->get('key', null, 'oauth_token'), 'secret' => $session->get('secret', null, 'oauth_token'));
@@ -135,7 +132,7 @@ abstract class Client
 			// Verify the returned request token.
 			if (strcmp($this->token['key'], $this->input->get('oauth_token')) !== 0)
 			{
-				throw new DomainException('Bad session!');
+				throw new \DomainException('Bad session!');
 			}
 
 			// Set token verifier for 1.0a.
@@ -181,14 +178,14 @@ abstract class Client
 
 		if (strcmp($this->version, '1.0a') === 0 && strcmp($params['oauth_callback_confirmed'], 'true') !== 0)
 		{
-			throw new DomainException('Bad request token!');
+			throw new \DomainException('Bad request token!');
 		}
 
 		// Save the request token.
 		$this->token = array('key' => $params['oauth_token'], 'secret' => $params['oauth_token_secret']);
 
 		// Save the request token in session
-		$session = Factory::getSession();
+		$session = $this->application->getSession();
 		$session->set('key', $this->token['key'], 'oauth_token');
 		$session->set('secret', $this->token['secret'], 'oauth_token');
 	}

--- a/src/Joomla/Oauth1/Tests/ClientTest.php
+++ b/src/Joomla/Oauth1/Tests/ClientTest.php
@@ -9,11 +9,8 @@ namespace Joomla\Oauth1\Tests;
 use Joomla\Oauth1\Client;
 use Joomla\Registry\Registry;
 use Joomla\Input\Input;
-use Joomla\Http\Http;
 use Joomla\Test\WebInspector;
-use Joomla\Factory;
-use stdClass;
-use Joomla\Test\TestHelper as TestHelper;
+use Joomla\Test\TestHelper;
 
 require_once __DIR__ . '/stubs/ClientInspector.php';
 
@@ -38,7 +35,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 	protected $options;
 
 	/**
-	 * @var    Http  Mock http object.
+	 * @var    object  Mock http object.
 	 * @since  1.0
 	 */
 	protected $client;
@@ -49,10 +46,10 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 	 * @var    ClientInspector
 	 * @since  1.0
 	 */
-	protected $class;
+	protected $object;
 
 	/**
-	 * @var   AbstractWebApplication  The application object to send HTTP headers for redirects.
+	 * @var   \Joomla\Application\AbstractWebApplication  The application object to send HTTP headers for redirects.
 	 */
 	protected $application;
 
@@ -90,20 +87,11 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 		$this->input = new Input;
 		$this->application = new WebInspector;
 
+		$this->application->setSession($this->getMock('Joomla\\Session\\Session'));
+
 		$this->options->set('consumer_key', $key);
 		$this->options->set('consumer_secret', $secret);
 		$this->object = new ClientInspector($this->options, $this->client, $this->input, $this->application);
-	}
-
-	/**
-	 * Tears down the fixture, for example, closes a network connection.
-	 * This method is called after a test is executed.
-	 *
-	 * @return void
-	 */
-	protected function tearDown()
-	{
-		Factory::$session = null;
 	}
 
 	/**
@@ -152,7 +140,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 			$this->object->setOption('accessTokenURL', 'https://example.com/access_token');
 
 			// Request token.
-			$returnData = new stdClass;
+			$returnData = new \stdClass;
 			$returnData->code = 200;
 			$returnData->body = 'oauth_token=token&oauth_token_secret=secret&oauth_callback_confirmed=true';
 
@@ -207,7 +195,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 							->with('secret', null, 'oauth_token')
 							->will($this->returnValue('session'));
 
-				Factory::$session = $mockSession;
+				$this->application->setSession($mockSession);
 
 				$this->setExpectedException('DomainException');
 				$result = $this->object->authenticate();
@@ -223,9 +211,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 						->with('secret', null, 'oauth_token')
 						->will($this->returnValue('secret'));
 
-			Factory::$session = $mockSession;
+			$this->application->setSession($mockSession);
 
-			$returnData = new stdClass;
+			$returnData = new \stdClass;
 			$returnData->code = 200;
 			$returnData->body = 'oauth_token=token_key&oauth_token_secret=token_secret';
 
@@ -253,7 +241,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 	{
 		$this->object->setOption('requestTokenURL', 'https://example.com/request_token');
 
-		$returnData = new stdClass;
+		$returnData = new \stdClass;
 		$returnData->code = 200;
 		$returnData->body = 'oauth_token=token&oauth_token_secret=secret&oauth_callback_confirmed=false';
 
@@ -294,7 +282,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testOauthRequest($method)
 	{
-		$returnData = new stdClass;
+		$returnData = new \stdClass;
 		$returnData->code = 200;
 		$returnData->body = $this->sampleString;
 

--- a/src/Joomla/Oauth2/Client.php
+++ b/src/Joomla/Oauth2/Client.php
@@ -12,10 +12,6 @@ use Joomla\Registry\Registry;
 use Joomla\Application\AbstractWebApplication;
 use Joomla\Input\Input;
 use Joomla\Http\Http;
-use Joomla\Factory;
-use InvalidArgumentException;
-use RuntimeException;
-use Exception;
 
 /**
  * Joomla Framework class for interacting with an OAuth 2.0 server.
@@ -58,12 +54,12 @@ class Client
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options = null, Http $http = null, Input $input = null, AbstractWebApplication $application = null)
+	public function __construct(Registry $options, Http $http, Input $input, AbstractWebApplication $application)
 	{
-		$this->options = isset($options) ? $options : new Registry;
-		$this->http = isset($http) ? $http : new Http($this->options);
-		$this->application = isset($application) ? $application : Factory::$application;
-		$this->input = isset($input) ? $input : $this->application->input;
+		$this->options = $options;
+		$this->http = $http;
+		$this->input = $input;
+		$this->application = $application;
 	}
 
 	/**
@@ -72,7 +68,7 @@ class Client
 	 * @return  string  The access token
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function authenticate()
 	{
@@ -102,7 +98,7 @@ class Client
 			}
 			else
 			{
-				throw new RuntimeException('Error code ' . $response->code . ' received requesting access token: ' . $response->body . '.');
+				throw new \RuntimeException('Error code ' . $response->code . ' received requesting access token: ' . $response->body . '.');
 			}
 		}
 
@@ -145,13 +141,13 @@ class Client
 	 * @return  \Joomla\Http\Response  The HTTP response
 	 *
 	 * @since   1.0
-	 * @throws  InvalidArgumentException
+	 * @throws  \InvalidArgumentException
 	 */
 	public function createUrl()
 	{
 		if (!$this->getOption('authurl') || !$this->getOption('clientid'))
 		{
-			throw new InvalidArgumentException('Authorization URL and client_id are required');
+			throw new \InvalidArgumentException('Authorization URL and client_id are required');
 		}
 
 		$url = $this->getOption('authurl');
@@ -207,8 +203,8 @@ class Client
 	 * @return  string  The URL.
 	 *
 	 * @since   1.0
-	 * @throws  InvalidArgumentException
-	 * @throws  RuntimeException
+	 * @throws  \InvalidArgumentException
+	 * @throws  \RuntimeException
 	 */
 	public function query($url, $data = null, $headers = array(), $method = 'get', $timeout = null)
 	{
@@ -259,12 +255,12 @@ class Client
 				break;
 
 			default:
-				throw new InvalidArgumentException('Unknown HTTP request method: ' . $method . '.');
+				throw new \InvalidArgumentException('Unknown HTTP request method: ' . $method . '.');
 		}
 
 		if ($response->code < 200 || $response->code >= 400)
 		{
-			throw new RuntimeException('Error code ' . $response->code . ' received requesting data: ' . $response->body . '.');
+			throw new \RuntimeException('Error code ' . $response->code . ' received requesting data: ' . $response->body . '.');
 		}
 
 		return $response;
@@ -343,14 +339,14 @@ class Client
 	 * @return  array  The new access token
 	 *
 	 * @since   1.0
-	 * @throws  Exception
-	 * @throws  RuntimeException
+	 * @throws  \Exception
+	 * @throws  \RuntimeException
 	 */
 	public function refreshToken($token = null)
 	{
 		if (!$this->getOption('userefresh'))
 		{
-			throw new RuntimeException('Refresh token is not supported for this OAuth instance.');
+			throw new \RuntimeException('Refresh token is not supported for this OAuth instance.');
 		}
 
 		if (!$token)
@@ -359,7 +355,7 @@ class Client
 
 			if (!array_key_exists('refresh_token', $token))
 			{
-				throw new RuntimeException('No refresh token is available.');
+				throw new \RuntimeException('No refresh token is available.');
 			}
 
 			$token = $token['refresh_token'];
@@ -389,7 +385,7 @@ class Client
 		}
 		else
 		{
-			throw new Exception('Error code ' . $response->code . ' received refreshing token: ' . $response->body . '.');
+			throw new \Exception('Error code ' . $response->code . ' received refreshing token: ' . $response->body . '.');
 		}
 	}
 }

--- a/src/Joomla/Twitter/OAuth.php
+++ b/src/Joomla/Twitter/OAuth.php
@@ -13,7 +13,6 @@ use Joomla\Registry\Registry;
 use Joomla\Http\Http;
 use Joomla\Input\Input;
 use Joomla\Application\AbstractWebApplication;
-use \DomainException;
 
 /**
  * Joomla Framework class for generating Twitter API access token.
@@ -38,9 +37,9 @@ class OAuth extends Client
 	 *
 	 * @since 1.0
 	 */
-	public function __construct(Registry $options = null, Http $client = null, Input $input = null, AbstractWebApplication $application = null)
+	public function __construct(Registry $options, Http $client, Input $input, AbstractWebApplication $application)
 	{
-		$this->options = isset($options) ? $options : new Registry;
+		$this->options = $options;
 
 		$this->options->def('accessTokenURL', 'https://api.twitter.com/oauth/access_token');
 		$this->options->def('authenticateURL', 'https://api.twitter.com/oauth/authenticate');
@@ -108,13 +107,13 @@ class OAuth extends Client
 	/**
 	 * Method to validate a response.
 	 *
-	 * @param   string         $url       The request URL.
-	 * @param   JHttpResponse  $response  The response to validate.
+	 * @param   string                 $url       The request URL.
+	 * @param   \Joomla\Http\Response  $response  The response to validate.
 	 *
 	 * @return  void
 	 *
 	 * @since  1.0
-	 * @throws DomainException
+	 * @throws \DomainException
 	 */
 	public function validateResponse($url, $response)
 	{
@@ -124,12 +123,12 @@ class OAuth extends Client
 
 			if (property_exists($error, 'error'))
 			{
-				throw new DomainException($error->error);
+				throw new \DomainException($error->error);
 			}
 			else
 			{
 				$error = $error->errors;
-				throw new DomainException($error[0]->message, $error[0]->code);
+				throw new \DomainException($error[0]->message, $error[0]->code);
 			}
 		}
 	}


### PR DESCRIPTION
This PR removes the last of the `Factory` usage (pending a couple other PR's being merged) by reworking the constructors of the `Oauth1\Client` and `Oauth2\Client` classes.

Previously, all constructor params were optional, and if not provided, the class would create the dependencies itself. This hides the complexity of the class behind default parameters, but is bad practice (IMO) because it also hides from the casual viewer what a classes true dependencies are.
