### PR TITLE
Start converting registry usage to an array.

### DIFF
--- a/src/Joomla/Cache/Apc.php
+++ b/src/Joomla/Cache/Apc.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Cache;
 
-use Joomla\Registry\Registry;
 use Psr\Cache\CacheItemInterface;
 
 /**
@@ -26,7 +25,7 @@ class Apc extends Cache
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct($options = null)
+	public function __construct($options = array())
 	{
 		parent::__construct($options);
 

--- a/src/Joomla/Cache/Cache.php
+++ b/src/Joomla/Cache/Cache.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Cache;
 
-use Joomla\Registry\Registry;
 use Psr\Cache\CacheInterface;
 use Psr\Cache\CacheItemInterface;
 
@@ -104,7 +103,7 @@ abstract class Cache implements CacheInterface
 	 */
 	public function getOption($key)
 	{
-		return $this->options[$key];
+		return isset($this->options[$key]) ? $this->options[$key] : null;
 	}
 
 	/**

--- a/src/Joomla/Cache/File.php
+++ b/src/Joomla/Cache/File.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Cache;
 
-use Joomla\Registry\Registry;
 use Psr\Cache\CacheItemInterface;
 
 /**
@@ -31,7 +30,7 @@ class File extends Cache
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct($options = null)
+	public function __construct($options = array())
 	{
 		parent::__construct($options);
 

--- a/src/Joomla/Cache/Memcached.php
+++ b/src/Joomla/Cache/Memcached.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Cache;
 
-use Joomla\Registry\Registry;
 use Psr\Cache\CacheItemInterface;
 
 /**
@@ -32,11 +31,11 @@ class Memcached extends Cache
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct($options = null)
+	public function __construct($options = array())
 	{
 		parent::__construct($options);
 
-		if (!extension_loaded('memcached') || !class_exists('\\Memcached'))
+		if (!extension_loaded('memcached') || !class_exists('Memcached'))
 		{
 			throw new \RuntimeException('Memcached not supported.');
 		}

--- a/src/Joomla/Cache/Tests/FileTest.php
+++ b/src/Joomla/Cache/Tests/FileTest.php
@@ -7,7 +7,6 @@
 namespace Joomla\Cache\Tests;
 
 use Joomla\Cache;
-use Joomla\Registry\Registry;
 use Joomla\Test\TestHelper;
 
 /**
@@ -223,8 +222,9 @@ class FileTest extends \PHPUnit_Framework_TestCase
 		// Clean up the test folder.
 		$this->tearDown();
 
-		$options = new Registry;
-		$options->set('file.path', __DIR__ . '/tmp');
+		$options = array(
+			'file.path' => __DIR__ . '/tmp'
+		);
 
 		$this->instance = new Cache\File($options);
 	}

--- a/src/Joomla/Cache/Wincache.php
+++ b/src/Joomla/Cache/Wincache.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Cache;
 
-use Joomla\Registry\Registry;
 use Psr\Cache\CacheItemInterface;
 
 /**
@@ -21,12 +20,12 @@ class Wincache extends Cache
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry  $options  Caching options object.
+	 * @param   array  $options  Caching options object.
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct($options = null)
+	public function __construct($options = array())
 	{
 		parent::__construct($options);
 

--- a/src/Joomla/Cache/XCache.php
+++ b/src/Joomla/Cache/XCache.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Cache;
 
-use Joomla\Registry\Registry;
 use Psr\Cache\CacheItemInterface;
 
 /**
@@ -21,12 +20,12 @@ class XCache extends Cache
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry  $options  Caching options object.
+	 * @param   array  $options  Caching options object.
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct($options = null)
+	public function __construct($options = array())
 	{
 		parent::__construct($options);
 

--- a/src/Joomla/Cache/composer.json
+++ b/src/Joomla/Cache/composer.json
@@ -12,7 +12,7 @@
          "joomla/test": "~1.0"
     },
     "suggest": {
-        "joomla/registry": "Registry can be used as an alternative to using an array for the caching options."
+        "joomla/registry": "Registry can be used as an alternative to using an array for the package options."
     },
     "target-dir": "Joomla/Cache",
     "autoload": {

--- a/src/Joomla/Facebook/Facebook.php
+++ b/src/Joomla/Facebook/Facebook.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Facebook;
 
-use Joomla\Registry\Registry;
 use Joomla\Http\Http;
 
 /**
@@ -19,7 +18,7 @@ use Joomla\Http\Http;
 class Facebook
 {
 	/**
-	 * @var    \Joomla\Registry\Registry  Options for the Facebook object.
+	 * @var    array  Options for the Facebook object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -111,20 +110,23 @@ class Facebook
 	/**
 	 * Constructor.
 	 *
-	 * @param   OAuth     $oauth    OAuth client.
-	 * @param   Registry  $options  Facebook options object.
-	 * @param   Http      $client   The HTTP client object.
+	 * @param   OAuth  $oauth    OAuth client.
+	 * @param   array  $options  Facebook options array.
+	 * @param   Http   $client   The HTTP client object.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(OAuth $oauth = null, Registry $options = null, Http $client = null)
+	public function __construct(OAuth $oauth = null, $options = array(), Http $client = null)
 	{
 		$this->oauth = $oauth;
-		$this->options = isset($options) ? $options : new Registry;
-		$this->client  = isset($client) ? $client : new Http($this->options);
+		$this->options = $options;
+		$this->client  = $client;
 
 		// Setup the default API url if not already set.
-		$this->options->def('api.url', 'https://graph.facebook.com/');
+		if (!isset($this->options['api.url']))
+		{
+			$this->options['api.url'] = 'https://graph.facebook.com/';
+		}
 	}
 
 	/**
@@ -139,9 +141,9 @@ class Facebook
 	 */
 	public function __get($name)
 	{
-		$class = '\\Joomla\\Facebook\\' . ucfirst($name);
+		$class = __NAMESPACE__ . '\\' . ucfirst(strtolower($name));
 
-		if (class_exists($class))
+		if (class_exists($class) && property_exists($this, $name))
 		{
 			if (false == isset($this->$name))
 			{
@@ -165,7 +167,7 @@ class Facebook
 	 */
 	public function getOption($key)
 	{
-		return $this->options->get($key);
+		return isset($this->options[$key]) ? $this->options[$key] : null;
 	}
 
 	/**
@@ -180,7 +182,7 @@ class Facebook
 	 */
 	public function setOption($key, $value)
 	{
-		$this->options->set($key, $value);
+		$this->options[$key] = $value;
 
 		return $this;
 	}

--- a/src/Joomla/Facebook/OAuth.php
+++ b/src/Joomla/Facebook/OAuth.php
@@ -8,9 +8,8 @@
 
 namespace Joomla\Facebook;
 
-use Joomla\Test\WebInspector;
+use Joomla\Application\AbstractWebApplication;
 use Joomla\Oauth2\Client;
-use Joomla\Registry\Registry;
 use Joomla\Http\Http;
 use Joomla\Input\Input;
 
@@ -22,7 +21,7 @@ use Joomla\Input\Input;
 class OAuth extends Client
 {
 	/**
-	 * @var \Joomla\Registry\Registry Options for the OAuth object.
+	 * @var   array  Options for the OAuth object.
 	 * @since 1.0
 	 */
 	protected $options;
@@ -30,20 +29,27 @@ class OAuth extends Client
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry      $options      JFacebookOauth options object.
-	 * @param   Http          $client       The HTTP client object.
-	 * @param   Input         $input        The input object.
-	 * @param   WebInspector  $application  The application object.
+	 * @param   array                   $options      Oauth options array.
+	 * @param   Http                    $client       The HTTP client object.
+	 * @param   Input                   $input        The input object.
+	 * @param   AbstractWebApplication  $application  The application object.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options, Http $client, Input $input, WebInspector $application)
+	public function __construct($options, Http $client, Input $input, AbstractWebApplication $application)
 	{
 		$this->options = $options;
 
 		// Setup the authentication and token urls if not already set.
-		$this->options->def('authurl', 'http://www.facebook.com/dialog/oauth');
-		$this->options->def('tokenurl', 'https://graph.facebook.com/oauth/access_token');
+		if (!isset($this->options['authurl']))
+		{
+			$this->options['authurl'] = 'http://www.facebook.com/dialog/oauth';
+		}
+
+		if (!isset($this->options['tokenurl']))
+		{
+			$this->options['tokenurl'] = 'https://graph.facebook.com/oauth/access_token';
+		}
 
 		// Call the Joomla\Oauth2\Client constructor to setup the object.
 		parent::__construct($this->options, $client, $input, $application);

--- a/src/Joomla/Facebook/Object.php
+++ b/src/Joomla/Facebook/Object.php
@@ -8,10 +8,8 @@
 
 namespace Joomla\Facebook;
 
-use Joomla\Registry\Registry;
 use Joomla\Http\Http;
 use Joomla\Uri\Uri;
-use RuntimeException;
 
 /**
  * Facebook API object class for the Joomla Framework.
@@ -21,13 +19,13 @@ use RuntimeException;
 abstract class Object
 {
 	/**
-	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
+	 * @var    array  Options for the Facebook object.
 	 * @since  1.0
 	 */
 	protected $options;
 
 	/**
-	 * @var    Joomla\Http\Http  The HTTP client object to use in sending HTTP requests.
+	 * @var    \Joomla\Http\Http  The HTTP client object to use in sending HTTP requests.
 	 * @since  1.0
 	 */
 	protected $client;
@@ -41,16 +39,16 @@ abstract class Object
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry  $options  Facebook options object.
-	 * @param   Http      $client   The HTTP client object.
-	 * @param   OAuth     $oauth    The OAuth client.
+	 * @param   array  $options  Facebook options array.
+	 * @param   Http   $client   The HTTP client object.
+	 * @param   OAuth  $oauth    The OAuth client.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options = null, Http $client = null, OAuth $oauth = null)
+	public function __construct($options = array(), Http $client = null, OAuth $oauth = null)
 	{
-		$this->options = isset($options) ? $options : new Registry;
-		$this->client = isset($client) ? $client : new Http($this->options);
+		$this->options = $options;
+		$this->client = $client;
 		$this->oauth = $oauth;
 	}
 
@@ -72,7 +70,8 @@ abstract class Object
 	protected function fetchUrl($path, $limit = 0, $offset = 0, $until = null, $since = null)
 	{
 		// Get a new Uri object fousing the api url and given path.
-		$uri = new Uri($this->options->get('api.url') . $path);
+		$apiUrl = isset($this->options['api.url']) ? $this->options['api.url'] : null;
+		$uri = new Uri($apiUrl . $path);
 
 		if ($limit > 0)
 		{
@@ -280,7 +279,7 @@ abstract class Object
 	 *
 	 * @param   OAuth  $oauth  The OAuth client object.
 	 *
-	 * @return  FacebookObject  This object for method chaining.
+	 * @return  Object  This object for method chaining.
 	 *
 	 * @since   1.0
 	 */

--- a/src/Joomla/Facebook/README.md
+++ b/src/Joomla/Facebook/README.md
@@ -23,14 +23,15 @@ Create a Facebook application at [https://developers.facebook.com/apps](https://
 ```php
 use Joomla\Facebook\Facebook;
 use Joomla\Facebook\OAuth;
-use Joomla\Registry\Registry;
 
-$options = new Registry;
-$options->set('clientid', $app_id);
-$options->set('clientsecret', $app_secret);
-$options->set('redirecturi', $callback_url);
-$options->set('sendheaders', true);
-$options->set('authmethod', 'get');
+$options = array(
+    'clientid' => $app_id,
+    'clientsecret' => $app_secret,
+    'redirecturi' => $callback_url,
+    'sendheaders' => true,
+    'authmethod' => 'get'
+);
+
 $oauth = new OAuth($options);
 
 $facebook = new Facebook($oauth);
@@ -83,18 +84,18 @@ Below is an example demonstrating more of the Facebook package.
 ```php
 use Joomla\Facebook\Facebook;
 use Joomla\Facebook\OAuth;
-use Joomla\Registry\Registry;
 
 $app_id = "app_id";
 $app_secret = "app_secret";
 $my_url = 'http://localhost/facebook_test.php';
 
-$options = new Registry;
-$options->set('clientid', $app_id);
-$options->set('clientsecret', $app_secret);
-$options->set('redirecturi', $my_url);
-$options->set('sendheaders', true);
-$options->set('authmethod', 'get');
+$options = array(
+    'clientid' => $app_id,
+    'clientsecret' => $app_secret,
+    'redirecturi' => $callback_url,
+    'sendheaders' => true,
+    'authmethod' => 'get'
+);
 
 $oauth = new OAuth($options);
 $oauth->authenticate();

--- a/src/Joomla/Facebook/Tests/FacebookTest.php
+++ b/src/Joomla/Facebook/Tests/FacebookTest.php
@@ -7,6 +7,7 @@
 namespace Joomla\Facebook\Tests;
 
 use Joomla\Facebook\Facebook;
+use Joomla\Test\TestHelper;
 
 require_once __DIR__ . '/case/FacebookTestCase.php';
 
@@ -238,8 +239,10 @@ class FacebookTest extends FacebookTestCase
 	{
 		$this->object->setOption('api.url', 'https://example.com/settest');
 
+		$value = TestHelper::getValue($this->object, 'options');
+
 		$this->assertThat(
-			$this->options->get('api.url'),
+			$value['api.url'],
 			$this->equalTo('https://example.com/settest')
 		);
 	}
@@ -253,10 +256,12 @@ class FacebookTest extends FacebookTestCase
 	 */
 	public function testGetOption()
 	{
-		$this->options->set('api.url', 'https://example.com/gettest');
+		TestHelper::setValue($this->object, 'options', array(
+				'api.url' => 'https://example.com/gettest'
+			));
 
 		$this->assertThat(
-			$this->object->getOption('api.url', 'https://example.com/gettest'),
+			$this->object->getOption('api.url'),
 			$this->equalTo('https://example.com/gettest')
 		);
 	}

--- a/src/Joomla/Facebook/Tests/OAuthTest.php
+++ b/src/Joomla/Facebook/Tests/OAuthTest.php
@@ -7,9 +7,9 @@
 namespace Joomla\Facebook\Tests;
 
 use Joomla\Facebook\OAuth;
-use Joomla\Registry\Registry;
 use Joomla\Input\Input;
 use Joomla\Test\WebInspector;
+use Joomla\Test\TestHelper;
 
 require_once __DIR__ . '/case/FacebookTestCase.php';
 
@@ -21,7 +21,7 @@ require_once __DIR__ . '/case/FacebookTestCase.php';
 class OAuthTest extends FacebookTestCase
 {
 	/**
-	 * @var    JApplicationWeb  The application object to send HTTP headers for redirects.
+	 * @var    WebInspector  The application object to send HTTP headers for redirects.
 	 */
 	protected $application;
 
@@ -42,8 +42,8 @@ class OAuthTest extends FacebookTestCase
 		$_SERVER['REQUEST_URI'] = '/index.php';
 		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
-		$this->options = new Registry;
-		$this->client = $this->getMock('\\Joomla\\Http\\Http', array('get', 'post', 'delete', 'put'));
+		$this->options = array();
+		$this->client = $this->getMock('Joomla\\Http\\Http', array('get', 'post', 'delete', 'put'));
 		$this->input = new Input;
 
 		$this->application = new WebInspector;
@@ -61,8 +61,10 @@ class OAuthTest extends FacebookTestCase
 	{
 		$this->object->setScope('read_stream');
 
+		$value = TestHelper::getValue($this->object, 'options');
+
 		$this->assertThat(
-			$this->options->get('scope'),
+			$value['scope'],
 			$this->equalTo('read_stream')
 		);
 	}
@@ -76,7 +78,9 @@ class OAuthTest extends FacebookTestCase
 	 */
 	public function testGetScope()
 	{
-		$this->options->set('scope', 'read_stream');
+		TestHelper::setValue($this->object, 'options', array(
+				'scope' => 'read_stream'
+			));
 
 		$this->assertThat(
 			$this->object->getScope(),

--- a/src/Joomla/Facebook/Tests/ObjectTest.php
+++ b/src/Joomla/Facebook/Tests/ObjectTest.php
@@ -6,8 +6,7 @@
 
 namespace Joomla\Facebook\Tests;
 
-use Joomla\Facebook\Object;
-use Joomla\Registry\Registry;
+use Joomla\Test\TestHelper;
 
 require_once __DIR__ . '/case/FacebookTestCase.php';
 require_once __DIR__ . '/stubs/ObjectMock.php';
@@ -36,8 +35,8 @@ class ObjectTest extends FacebookTestCase
 		$_SERVER['REQUEST_URI'] = '/index.php';
 		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
-		$this->options = new Registry;
-		$this->client = $this->getMock('\\Joomla\\Http\\Http', array('get', 'post', 'delete', 'put'));
+		$this->options = array();
+		$this->client = $this->getMock('Joomla\\Http\\Http', array('get', 'post', 'delete', 'put'));
 
 		$this->object = new ObjectMock($this->options, $this->client);
 	}
@@ -83,7 +82,9 @@ class ObjectTest extends FacebookTestCase
 		$apiUrl = 'https://graph.facebook.com/';
 		$path = '456431243/likes?access_token=235twegsdgsdhtry3tgwgf';
 
-		$this->options->set('api.url', $apiUrl);
+		TestHelper::setValue($this->object, 'options', array(
+				'api.url' => $apiUrl
+			));
 
 		$this->assertThat(
 			$this->object->fetchUrl($path, $limit, $offset, $until, $since),

--- a/src/Joomla/Facebook/Tests/VideoTest.php
+++ b/src/Joomla/Facebook/Tests/VideoTest.php
@@ -120,7 +120,7 @@ class VideoTest extends FacebookTestCase
 	 * @return  void
 	 *
 	 * @since   1.0
-	 * @expectedException  RuntimeException
+	 * @expectedException  \RuntimeException
 	 */
 	public function testGetCommentsFailure()
 	{

--- a/src/Joomla/Facebook/Tests/case/FacebookTestCase.php
+++ b/src/Joomla/Facebook/Tests/case/FacebookTestCase.php
@@ -7,12 +7,8 @@
 namespace Joomla\Facebook\Tests;
 
 use Joomla\Facebook\OAuth;
-use Joomla\Registry\Registry;
-use Joomla\Http\Http;
 use Joomla\Input\Input;
 use Joomla\Test\WebInspector;
-use stdClass;
-use RuntimeException;
 
 /**
  * Test case for Facebook.
@@ -22,31 +18,31 @@ use RuntimeException;
 class FacebookTestCase extends \PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    array  Options for the Facebook object.
 	 * @since  1.0
 	 */
 	protected $options;
 
 	/**
-	 * @var    JFacebookOauth  OAuth client for Facebook.
+	 * @var    OAuth  OAuth client for Facebook.
 	 * @since  1.0
 	 */
 	protected $oauth;
 
 	/**
-	 * @var    JHttp  Mock client object.
+	 * @var    object  Mock client object.
 	 * @since  1.0
 	 */
 	protected $client;
 
 	/**
-	 * @var    JFacebookAlbum  Object under test.
+	 * @var    object  Object under test.
 	 * @since  1.0
 	 */
 	protected $object;
 
 	/**
-	 * @var    JApplicationWeb  The application object to send HTTP headers for redirects.
+	 * @var    WebInspector  The application object to send HTTP headers for redirects.
 	 */
 	protected $application;
 
@@ -88,18 +84,19 @@ class FacebookTestCase extends \PHPUnit_Framework_TestCase
 				'access_token' => 'token',
 				'expires' => '51837673', 'created' => '2443672521');
 
-		$this->options = new Registry;
-		$this->client = $this->getMock('\\Joomla\\Http\\Http', array('get', 'post', 'delete', 'put'));
+		$this->options = array();
+
+		$this->options['clientid'] = $app_id;
+		$this->options['clientsecret'] = $app_secret;
+		$this->options['redirecturi'] = $my_url;
+		$this->options['sendheaders'] = true;
+		$this->options['authmethod'] = 'get';
+
+		$this->client = $this->getMock('Joomla\\Http\\Http', array('get', 'post', 'delete', 'put'));
 		$this->input = new Input;
 		$this->application = new WebInspector;
 		$this->oauth = new OAuth($this->options, $this->client, $this->input, $this->application);
 		$this->oauth->setToken($access_token);
-
-		$this->options->set('clientid', $app_id);
-		$this->options->set('clientsecret', $app_secret);
-		$this->options->set('redirecturi', $my_url);
-		$this->options->set('sendheaders', true);
-		$this->options->set('authmethod', 'get');
 	}
 
 	/**

--- a/src/Joomla/Facebook/composer.json
+++ b/src/Joomla/Facebook/composer.json
@@ -10,11 +10,13 @@
         "joomla/oauth2": "~1.0",
         "joomla/input": "~1.0",
         "joomla/http": "~1.0",
-        "joomla/registry": "~1.0",
         "joomla/uri": "~1.0"
     },
     "require-dev": {
         "joomla/test": "~1.0"
+    },
+    "suggest": {
+        "joomla/registry": "Registry can be used as an alternative to using an array for the package options."
     },
     "target-dir": "Joomla/Facebook",
     "autoload": {

--- a/src/Joomla/Github/Github.php
+++ b/src/Joomla/Github/Github.php
@@ -33,7 +33,7 @@ use Joomla\Registry\Registry;
 class Github
 {
 	/**
-	 * @var    Registry  Options for the GitHub object.
+	 * @var    array  Options for the GitHub object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -58,7 +58,10 @@ class Github
 		$this->client  = isset($client) ? $client : new Http($this->options);
 
 		// Setup the default API url if not already set.
-		$this->options->def('api.url', 'https://api.github.com');
+		if (!$this->getOption('api.url'))
+		{
+			$this->setOption('api.url', 'https://api.github.com');
+		}
 	}
 
 	/**
@@ -73,7 +76,7 @@ class Github
 	 */
 	public function __get($name)
 	{
-		$class = '\\Joomla\\Github\\Package\\' . ucfirst($name);
+		$class = 'Joomla\\Github\\Package\\' . ucfirst($name);
 
 		if (class_exists($class))
 		{
@@ -99,7 +102,7 @@ class Github
 	 */
 	public function getOption($key)
 	{
-		return $this->options->get($key);
+		return isset($this->options[$key]) ? $this->options[$key] : null;
 	}
 
 	/**
@@ -114,7 +117,7 @@ class Github
 	 */
 	public function setOption($key, $value)
 	{
-		$this->options->set($key, $value);
+		$this->options[$key] = $value;
 
 		return $this;
 	}

--- a/src/Joomla/Github/Http.php
+++ b/src/Joomla/Github/Http.php
@@ -10,7 +10,6 @@ namespace Joomla\Github;
 
 use Joomla\Http\Http as BaseHttp;
 use Joomla\Http\TransportInterface;
-use Joomla\Registry\Registry;
 
 /**
  * HTTP client class for connecting to a GitHub instance.
@@ -40,20 +39,26 @@ class Http extends BaseHttp
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry            $options    Client options object.
+	 * @param   array               $options    Client options array.
 	 * @param   TransportInterface  $transport  The HTTP transport object.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options = null, TransportInterface $transport = null)
+	public function __construct($options = array(), TransportInterface $transport = null)
 	{
 		// Call the JHttp constructor to setup the object.
 		parent::__construct($options, $transport);
 
 		// Make sure the user agent string is defined.
-		$this->options->def('userAgent', 'JGitHub/2.0');
+		if (!isset($this->options['userAgent']))
+		{
+			$this->options['userAgent'] = 'JGitHub/2.0';
+		}
 
 		// Set the default timeout to 120 seconds.
-		$this->options->def('timeout', 120);
+		if (!isset($this->options['timeout']))
+		{
+			$this->options['timeout'] = 120;
+		}
 	}
 }

--- a/src/Joomla/Google/Auth.php
+++ b/src/Joomla/Google/Auth.php
@@ -16,7 +16,7 @@ namespace Joomla\Google;
 abstract class Auth
 {
 	/**
-	 * @var    \Joomla\Registry\Registry  Options for the Google authentication object.
+	 * @var    array  Options for the Google authentication object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -64,7 +64,7 @@ abstract class Auth
 	 */
 	public function getOption($key)
 	{
-		return $this->options->get($key);
+		return isset($this->options[$key]) ? $this->options[$key] : null;
 	}
 
 	/**
@@ -79,7 +79,7 @@ abstract class Auth
 	 */
 	public function setOption($key, $value)
 	{
-		$this->options->set($key, $value);
+		$this->options[$key] = $value;
 
 		return $this;
 	}

--- a/src/Joomla/Google/Data.php
+++ b/src/Joomla/Google/Data.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Google;
 
-use Joomla\Registry\Registry;
 use UnexpectedValueException;
 use SimpleXMLElement;
 use Exception;
@@ -21,7 +20,7 @@ use Exception;
 abstract class Data
 {
 	/**
-	 * @var    Registry  Options for the Google data object.
+	 * @var    array  Options for the Google data object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -40,9 +39,9 @@ abstract class Data
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options = null, Auth $auth = null)
+	public function __construct($options = array(), Auth $auth = null)
 	{
-		$this->options = isset($options) ? $options : new Registry;
+		$this->options = $options;
 		$this->auth = isset($auth) ? $auth : new Auth\Oauth2($this->options);
 	}
 
@@ -167,7 +166,7 @@ abstract class Data
 	 */
 	public function getOption($key)
 	{
-		return $this->options->get($key);
+		return isset($this->options[$key]) ? $this->options[$key] : null;
 	}
 
 	/**
@@ -182,7 +181,7 @@ abstract class Data
 	 */
 	public function setOption($key, $value)
 	{
-		$this->options->set($key, $value);
+		$this->options[$key] = $value;
 
 		return $this;
 	}

--- a/src/Joomla/Google/Embed.php
+++ b/src/Joomla/Google/Embed.php
@@ -9,7 +9,6 @@
 namespace Joomla\Google;
 
 use Joomla\Uri\Uri;
-use Joomla\Registry\Registry;
 
 /**
  * Google API object class for the Joomla Framework.
@@ -38,9 +37,9 @@ abstract class Embed
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options = null, Uri $uri = null)
+	public function __construct($options = array(), Uri $uri = null)
 	{
-		$this->options = $options ? $options : new Registry;
+		$this->options = $options;
 		$this->uri = $uri ? $uri : new Uri;
 	}
 
@@ -109,7 +108,7 @@ abstract class Embed
 	 */
 	public function getOption($key)
 	{
-		return $this->options->get($key);
+		return isset($this->options[$key]) ? $this->options[$key] : null;
 	}
 
 	/**
@@ -124,7 +123,7 @@ abstract class Embed
 	 */
 	public function setOption($key, $value)
 	{
-		$this->options->set($key, $value);
+		$this->options[$key] = $value;
 
 		return $this;
 	}

--- a/src/Joomla/Google/Google.php
+++ b/src/Joomla/Google/Google.php
@@ -8,8 +8,6 @@
 
 namespace Joomla\Google;
 
-use Joomla\Registry\Registry;
-
 /**
  * Joomla Framework class for interacting with the Google APIs.
  *
@@ -21,7 +19,7 @@ use Joomla\Registry\Registry;
 class Google
 {
 	/**
-	 * @var    Registry  Options for the Google object.
+	 * @var    array  Options for the Google object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -52,9 +50,9 @@ class Google
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options = null, Auth $auth = null)
+	public function __construct($options = array(), Auth $auth = null)
 	{
-		$this->options = isset($options) ? $options : new Registry;
+		$this->options = $options;
 		$this->auth  = isset($auth) ? $auth : new Auth\Oauth2($this->options);
 	}
 
@@ -141,7 +139,7 @@ class Google
 	 */
 	public function getOption($key)
 	{
-		return $this->options->get($key);
+		return isset($this->options[$key]) ? $this->options[$key] : null;
 	}
 
 	/**
@@ -156,7 +154,7 @@ class Google
 	 */
 	public function setOption($key, $value)
 	{
-		$this->options->set($key, $value);
+		$this->options[$key] = $value;
 
 		return $this;
 	}

--- a/src/Joomla/Http/Http.php
+++ b/src/Joomla/Http/Http.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Http;
 
-use Joomla\Registry\Registry;
 use Joomla\Uri\Uri;
 
 /**
@@ -19,7 +18,7 @@ use Joomla\Uri\Uri;
 class Http
 {
 	/**
-	 * @var    Registry  Options for the HTTP client.
+	 * @var    array  Options for the HTTP client.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -33,15 +32,15 @@ class Http
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry            $options    Client options object. If the registry contains any headers.* elements,
+	 * @param   array               $options    Client options array. If the registry contains any headers.* elements,
 	 *                                          these will be added to the request headers.
 	 * @param   TransportInterface  $transport  The HTTP transport object.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options = null, TransportInterface $transport = null)
+	public function __construct($options = array(), TransportInterface $transport = null)
 	{
-		$this->options   = isset($options) ? $options : new Registry;
+		$this->options   = $options;
 		$this->transport = isset($transport) ? $transport : HttpFactory::getAvailableDriver($this->options);
 	}
 
@@ -56,7 +55,7 @@ class Http
 	 */
 	public function getOption($key)
 	{
-		return $this->options->get($key);
+		return isset($this->options[$key]) ? $this->options[$key] : null;
 	}
 
 	/**
@@ -71,7 +70,7 @@ class Http
 	 */
 	public function setOption($key, $value)
 	{
-		$this->options->set($key, $value);
+		$this->options[$key] = $value;
 
 		return $this;
 	}
@@ -89,24 +88,7 @@ class Http
 	 */
 	public function options($url, array $headers = null, $timeout = null)
 	{
-		// Look for headers set in the options.
-		$temp = (array) $this->options->get('headers');
-
-		foreach ($temp as $key => $val)
-		{
-			if (!isset($headers[$key]))
-			{
-				$headers[$key] = $val;
-			}
-		}
-
-		// Look for timeout set in the options.
-		if ($timeout === null && $this->options->exists('timeout'))
-		{
-			$timeout = $this->options->get('timeout');
-		}
-
-		return $this->transport->request('OPTIONS', new Uri($url), null, $headers, $timeout, $this->options->get('userAgent', null));
+		return $this->makeTransportRequest('OPTIONS', $url, null, $headers, $timeout);
 	}
 
 	/**
@@ -122,24 +104,7 @@ class Http
 	 */
 	public function head($url, array $headers = null, $timeout = null)
 	{
-		// Look for headers set in the options.
-		$temp = (array) $this->options->get('headers');
-
-		foreach ($temp as $key => $val)
-		{
-			if (!isset($headers[$key]))
-			{
-				$headers[$key] = $val;
-			}
-		}
-
-		// Look for timeout set in the options.
-		if ($timeout === null && $this->options->exists('timeout'))
-		{
-			$timeout = $this->options->get('timeout');
-		}
-
-		return $this->transport->request('HEAD', new Uri($url), null, $headers, $timeout, $this->options->get('userAgent', null));
+		return $this->makeTransportRequest('HEAD', $url, null, $headers, $timeout);
 	}
 
 	/**
@@ -155,24 +120,7 @@ class Http
 	 */
 	public function get($url, array $headers = null, $timeout = null)
 	{
-		// Look for headers set in the options.
-		$temp = (array) $this->options->get('headers');
-
-		foreach ($temp as $key => $val)
-		{
-			if (!isset($headers[$key]))
-			{
-				$headers[$key] = $val;
-			}
-		}
-
-		// Look for timeout set in the options.
-		if ($timeout === null && $this->options->exists('timeout'))
-		{
-			$timeout = $this->options->get('timeout');
-		}
-
-		return $this->transport->request('GET', new Uri($url), null, $headers, $timeout, $this->options->get('userAgent', null));
+		return $this->makeTransportRequest('GET', $url, null, $headers, $timeout);
 	}
 
 	/**
@@ -189,24 +137,7 @@ class Http
 	 */
 	public function post($url, $data, array $headers = null, $timeout = null)
 	{
-		// Look for headers set in the options.
-		$temp = (array) $this->options->get('headers');
-
-		foreach ($temp as $key => $val)
-		{
-			if (!isset($headers[$key]))
-			{
-				$headers[$key] = $val;
-			}
-		}
-
-		// Look for timeout set in the options.
-		if ($timeout === null && $this->options->exists('timeout'))
-		{
-			$timeout = $this->options->get('timeout');
-		}
-
-		return $this->transport->request('POST', new Uri($url), $data, $headers, $timeout, $this->options->get('userAgent', null));
+		return $this->makeTransportRequest('POST', $url, $data, $headers, $timeout);
 	}
 
 	/**
@@ -223,24 +154,7 @@ class Http
 	 */
 	public function put($url, $data, array $headers = null, $timeout = null)
 	{
-		// Look for headers set in the options.
-		$temp = (array) $this->options->get('headers');
-
-		foreach ($temp as $key => $val)
-		{
-			if (!isset($headers[$key]))
-			{
-				$headers[$key] = $val;
-			}
-		}
-
-		// Look for timeout set in the options.
-		if ($timeout === null && $this->options->exists('timeout'))
-		{
-			$timeout = $this->options->get('timeout');
-		}
-
-		return $this->transport->request('PUT', new Uri($url), $data, $headers, $timeout, $this->options->get('userAgent', null));
+		return $this->makeTransportRequest('PUT', $url, $data, $headers, $timeout);
 	}
 
 	/**
@@ -257,24 +171,7 @@ class Http
 	 */
 	public function delete($url, array $headers = null, $timeout = null, $data = null)
 	{
-		// Look for headers set in the options.
-		$temp = (array) $this->options->get('headers');
-
-		foreach ($temp as $key => $val)
-		{
-			if (!isset($headers[$key]))
-			{
-				$headers[$key] = $val;
-			}
-		}
-
-		// Look for timeout set in the options.
-		if ($timeout === null && $this->options->exists('timeout'))
-		{
-			$timeout = $this->options->get('timeout');
-		}
-
-		return $this->transport->request('DELETE', new Uri($url), $data, $headers, $timeout, $this->options->get('userAgent', null));
+		return $this->makeTransportRequest('DELETE', $url, $data, $headers, $timeout);
 	}
 
 	/**
@@ -290,24 +187,7 @@ class Http
 	 */
 	public function trace($url, array $headers = null, $timeout = null)
 	{
-		// Look for headers set in the options.
-		$temp = (array) $this->options->get('headers');
-
-		foreach ($temp as $key => $val)
-		{
-			if (!isset($headers[$key]))
-			{
-				$headers[$key] = $val;
-			}
-		}
-
-		// Look for timeout set in the options.
-		if ($timeout === null && $this->options->exists('timeout'))
-		{
-			$timeout = $this->options->get('timeout');
-		}
-
-		return $this->transport->request('TRACE', new Uri($url), null, $headers, $timeout, $this->options->get('userAgent', null));
+		return $this->makeTransportRequest('TRACE', $url, null, $headers, $timeout);
 	}
 
 	/**
@@ -324,23 +204,46 @@ class Http
 	 */
 	public function patch($url, $data, array $headers = null, $timeout = null)
 	{
-		// Look for headers set in the options.
-		$temp = (array) $this->options->get('headers');
+		return $this->makeTransportRequest('PATCH', $url, $data, $headers, $timeout);
+	}
 
-		foreach ($temp as $key => $val)
+	/**
+	 * Send a request to the server and return a JHttpResponse object with the response.
+	 *
+	 * @param   string   $method     The HTTP method for sending the request.
+	 * @param   string   $uri        The URI to the resource to request.
+	 * @param   mixed    $data       Either an associative array or a string to be sent with the request.
+	 * @param   array    $headers    An array of request headers to send with the request.
+	 * @param   integer  $timeout    Read timeout in seconds.
+	 *
+	 * @return  Response
+	 *
+	 * @since   1.0
+	 */
+	protected function makeTransportRequest($method, $url, $data = null, array $headers = null, $timeout = null)
+	{
+		// Look for headers set in the options.
+		if (isset($this->options['headers']))
 		{
-			if (!isset($headers[$key]))
+			$temp = (array) $this->options['headers'];
+
+			foreach ($temp as $key => $val)
 			{
-				$headers[$key] = $val;
+				if (!isset($headers[$key]))
+				{
+					$headers[$key] = $val;
+				}
 			}
 		}
 
 		// Look for timeout set in the options.
-		if ($timeout === null && $this->options->exists('timeout'))
+		if ($timeout === null && isset($this->options['timeout']))
 		{
-			$timeout = $this->options->get('timeout');
+			$timeout = $this->options['timeout'];
 		}
 
-		return $this->transport->request('PATCH', new Uri($url), $data, $headers, $timeout, $this->options->get('userAgent', null));
+		$userAgent = isset($this->options['userAgent']) ? $this->options['userAgent'] : null;
+
+		return $this->transport->request($method, new Uri($url), $data, $headers, $timeout, $userAgent);
 	}
 }

--- a/src/Joomla/Http/HttpFactory.php
+++ b/src/Joomla/Http/HttpFactory.php
@@ -8,8 +8,6 @@
 
 namespace Joomla\Http;
 
-use Joomla\Registry\Registry;
-
 /**
  * HTTP factory class.
  *
@@ -18,10 +16,10 @@ use Joomla\Registry\Registry;
 class HttpFactory
 {
 	/**
-	 * Method to recieve Http instance.
+	 * Method to receive Http instance.
 	 *
-	 * @param   Registry  $options   Client options object.
-	 * @param   mixed     $adapters  Adapter (string) or queue of adapters (array) to use for communication.
+	 * @param   array  $options   Client options array.
+	 * @param   mixed  $adapters  Adapter (string) or queue of adapters (array) to use for communication.
 	 *
 	 * @return  Http  Joomla Http class
 	 *
@@ -29,13 +27,8 @@ class HttpFactory
 	 *
 	 * @since   1.0
 	 */
-	public static function getHttp(Registry $options = null, $adapters = null)
+	public static function getHttp($options = array(), $adapters = null)
 	{
-		if (empty($options))
-		{
-			$options = new Registry;
-		}
-
 		if (!$driver = self::getAvailableDriver($options, $adapters))
 		{
 			throw new \RuntimeException('No transport driver available.');
@@ -47,14 +40,14 @@ class HttpFactory
 	/**
 	 * Finds an available http transport object for communication
 	 *
-	 * @param   Registry  $options  Option for creating http transport object
-	 * @param   mixed     $default  Adapter (string) or queue of adapters (array) to use
+	 * @param   array  $options  Option for creating http transport object
+	 * @param   mixed  $default  Adapter (string) or queue of adapters (array) to use
 	 *
 	 * @return  TransportInterface  Interface sub-class
 	 *
 	 * @since   1.0
 	 */
-	public static function getAvailableDriver(Registry $options, $default = null)
+	public static function getAvailableDriver($options, $default = null)
 	{
 		if (is_null($default))
 		{
@@ -75,7 +68,7 @@ class HttpFactory
 		foreach ($availableAdapters as $adapter)
 		{
 			/* @var  $class  TransportInterface */
-			$class = '\\Joomla\\Http\\Transport\\' . ucfirst($adapter);
+			$class = 'Joomla\\Http\\Transport\\' . ucfirst($adapter);
 
 			if (class_exists($class))
 			{

--- a/src/Joomla/Http/README.md
+++ b/src/Joomla/Http/README.md
@@ -18,14 +18,13 @@ The `Http\Http` class provides methods for making RESTful requests.
 
 ##### Construction
 
-Construction of `Http\Http` object is generally done using the `Http\HttpFactory` class. However, `Http\Http` is not abstract and can be instantiated directly passing an optional Registry object of options and an optional `Http\TransportInterface` object. If the transport is omitted, the default transport will be used. The default is determined by looking up the transports folder and selecting the first transport that is supported (this will usually be the "curl" transport).
+Construction of `Http\Http` object is generally done using the `Http\HttpFactory` class. However, `Http\Http` is not abstract and can be instantiated directly passing an optional array of options and an optional `Http\TransportInterface` object. If the transport is omitted, the default transport will be used. The default is determined by looking up the transports folder and selecting the first transport that is supported (this will usually be the "curl" transport).
 
 ```php
 use Joomla\Http\Http;
 use Joomla\Http\Transport\Stream as StreamTransport;
-use Joomla\Registry\Registry;
 
-$options = new Registry;
+$options = array();
 
 $transport = new StreamTransport($options);
 
@@ -105,16 +104,14 @@ An HTTP TRACE request can be made using the trace method passing a URL and an op
 
 ##### Working with options
 
-Customs headers can be pased into each REST request, but they can also be set globally in the constructor options where the registry path starts with "headers.". In the case where a request method passes additional headers, those will override the headers set in the options.
+Customs headers can be pased into each REST request, but they can also be set globally in the constructor options where the option path starts with "headers.". In the case where a request method passes additional headers, those will override the headers set in the options.
 
 ```php
-use Joomla\Registry\Registry;
-
-// Create the options.
-$options = new Registry;
 
 // Configure a custom Accept header for all requests.
-$options->set('headers.Accept', 'application/vnd.github.html+json');
+$options = array(
+    'headers.Accept' => 'application/vnd.github.html+json'
+);
 
 // Make the request, knowing the custom Accept header will be used.
 $pull = $http->get('https://api.github.com/repos/joomla/joomla-platform/pulls/1');

--- a/src/Joomla/Http/Tests/FactoryTest.php
+++ b/src/Joomla/Http/Tests/FactoryTest.php
@@ -7,7 +7,6 @@
 namespace Joomla\Http\Tests;
 
 use Joomla\Http\HttpFactory;
-use Joomla\Registry\Registry;
 
 /**
  * Test class for Joomla\Http\HttpFactory.
@@ -27,7 +26,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 	{
 		$this->assertThat(
 			HttpFactory::getHttp(),
-			$this->isInstanceOf('\\Joomla\\Http\\Http')
+			$this->isInstanceOf('Joomla\\Http\\Http')
 		);
 	}
 
@@ -41,13 +40,13 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 	public function testGetAvailableDriver()
 	{
 		$this->assertThat(
-			HttpFactory::getAvailableDriver(new Registry, array()),
+			HttpFactory::getAvailableDriver(array(), array()),
 			$this->isFalse(),
 			'Passing an empty array should return false due to there being no adapters to test'
 		);
 
 		$this->assertThat(
-			HttpFactory::getAvailableDriver(new Registry, array('fopen')),
+			HttpFactory::getAvailableDriver(array(), array('fopen')),
 			$this->isFalse(),
 			'A false should be returned if a class is not present or supported'
 		);

--- a/src/Joomla/Http/Tests/HttpTest.php
+++ b/src/Joomla/Http/Tests/HttpTest.php
@@ -7,8 +7,8 @@
 namespace Joomla\Http\Tests;
 
 use Joomla\Http\Http;
-use Joomla\Registry\Registry;
 use Joomla\Uri\Uri;
+use Joomla\Test\TestHelper;
 
 /**
  * Test class for Joomla\Http\Http.
@@ -18,7 +18,7 @@ use Joomla\Uri\Uri;
 class HttpTest extends \PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    Registry  Options for the Http object.
+	 * @var    array  Options for the Http object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -48,7 +48,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
 		parent::setUp();
 
 		static $classNumber = 1;
-		$this->options = $this->getMock('Joomla\\Registry\\Registry', array('get', 'set'));
+		$this->options = array();
 		$this->transport = $this->getMock(
 			'Joomla\Http\Transport\Stream',
 			array('request'),
@@ -69,14 +69,13 @@ class HttpTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testGetOption()
 	{
-		$this->options->expects($this->once())
-			->method('get')
-			->with('testkey')
-			->will($this->returnValue('testResult'));
+		$this->object->setOption('testKey', 'testValue');
+
+		$value = TestHelper::getValue($this->object, 'options');
 
 		$this->assertThat(
-			$this->object->getOption('testkey'),
-			$this->equalTo('testResult')
+			$value['testKey'],
+			$this->equalTo('testValue')
 		);
 	}
 
@@ -89,13 +88,13 @@ class HttpTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testSetOption()
 	{
-		$this->options->expects($this->once())
-			->method('set')
-			->with('testkey', 'testvalue');
+		TestHelper::setValue($this->object, 'options', array(
+				'testKey' => 'testValue'
+			));
 
 		$this->assertThat(
-			$this->object->setOption('testkey', 'testvalue'),
-			$this->equalTo($this->object)
+			$this->object->getOption('testKey'),
+			$this->equalTo('testValue')
 		);
 	}
 

--- a/src/Joomla/Http/Transport/Curl.php
+++ b/src/Joomla/Http/Transport/Curl.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Http\Transport;
 
-use Joomla\Registry\Registry;
 use Joomla\Http\TransportInterface;
 use Joomla\Http\Response;
 use Joomla\Uri\UriInterface;
@@ -21,7 +20,7 @@ use Joomla\Uri\UriInterface;
 class Curl implements TransportInterface
 {
 	/**
-	 * @var    Registry  The client options.
+	 * @var    array  The client options.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -29,13 +28,13 @@ class Curl implements TransportInterface
 	/**
 	 * Constructor. CURLOPT_FOLLOWLOCATION must be disabled when open_basedir or safe_mode are enabled.
 	 *
-	 * @param   Registry  $options  Client options object.
+	 * @param   array  $options  Client options array.
 	 *
 	 * @see     http://www.php.net/manual/en/function.curl-setopt.php
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct(Registry $options)
+	public function __construct($options = array())
 	{
 		if (!function_exists('curl_init') || !is_callable('curl_init'))
 		{
@@ -72,7 +71,7 @@ class Curl implements TransportInterface
 		$options[CURLOPT_NOBODY] = ($method === 'HEAD');
 
 		// Initialize the certificate store
-		$options[CURLOPT_CAINFO] = $this->options->get('curl.certpath', __DIR__ . '/cacert.pem');
+		$options[CURLOPT_CAINFO] = isset($this->options['curl.certpath']) ? $this->options['curl.certpath'] : __DIR__ . '/cacert.pem';
 
 		// If data exists let's encode it and make sure our Content-type header is set.
 		if (isset($data))
@@ -141,7 +140,7 @@ class Curl implements TransportInterface
 		$options[CURLOPT_HTTPHEADER][] = 'Expect:';
 
 		// Follow redirects.
-		$options[CURLOPT_FOLLOWLOCATION] = (bool) $this->options->get('follow_location', true);
+		$options[CURLOPT_FOLLOWLOCATION] = (bool) (isset($this->options['follow_location']) ? $this->options['follow_location'] : true);
 
 		// Set the cURL options.
 		curl_setopt_array($ch, $options);

--- a/src/Joomla/Http/Transport/Socket.php
+++ b/src/Joomla/Http/Transport/Socket.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Http\Transport;
 
-use Joomla\Registry\Registry;
 use Joomla\Http\TransportInterface;
 use Joomla\Http\Response;
 use Joomla\Uri\UriInterface;
@@ -27,7 +26,7 @@ class Socket implements TransportInterface
 	protected $connections;
 
 	/**
-	 * @var    Registry  The client options.
+	 * @var    array  The client options.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -35,12 +34,12 @@ class Socket implements TransportInterface
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry  $options  Client options object.
+	 * @param   array  $options  Client options object.
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct(Registry $options)
+	public function __construct($options = array())
 	{
 		if (!self::isSupported())
 		{

--- a/src/Joomla/Http/Transport/Stream.php
+++ b/src/Joomla/Http/Transport/Stream.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Http\Transport;
 
-use Joomla\Registry\Registry;
 use Joomla\Http\TransportInterface;
 use Joomla\Http\Response;
 use Joomla\Uri\UriInterface;
@@ -21,7 +20,7 @@ use Joomla\Uri\UriInterface;
 class Stream implements TransportInterface
 {
 	/**
-	 * @var    Registry  The client options.
+	 * @var    array  The client options.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -29,12 +28,12 @@ class Stream implements TransportInterface
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry  $options  Client options object.
+	 * @param   array  $options  Client options object.
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public function __construct(Registry $options)
+	public function __construct($options = array())
 	{
 		// Verify that fopen() is available.
 		if (!self::isSupported())

--- a/src/Joomla/Http/TransportInterface.php
+++ b/src/Joomla/Http/TransportInterface.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Http;
 
-use Joomla\Registry\Registry;
 use Joomla\Uri\UriInterface;
 
 /**
@@ -21,11 +20,11 @@ interface TransportInterface
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry  $options  Client options object.
+	 * @param   array  $options  Client options object.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options);
+	public function __construct($options = array());
 
 	/**
 	 * Send a request to the server and return a JHttpResponse object with the response.

--- a/src/Joomla/Http/composer.json
+++ b/src/Joomla/Http/composer.json
@@ -7,8 +7,10 @@
     "license": "GPL-2.0+",
     "require": {
         "php": ">=5.3.10",
-        "joomla/registry": "~1.0",
         "joomla/uri": "~1.0"
+    },
+    "suggest": {
+        "joomla/registry": "Registry can be used as an alternative to using an array for the package options."
     },
     "target-dir": "Joomla/Http",
     "autoload": {

--- a/src/Joomla/Linkedin/Linkedin.php
+++ b/src/Joomla/Linkedin/Linkedin.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Linkedin;
 
-use Joomla\Registry\Registry;
 use Joomla\Http\Http;
 use Joomla\Linkedin\OAuth;
 use Joomla\Linkedin\People;
@@ -26,7 +25,7 @@ use Joomla\Linkedin\Jobs;
 class Linkedin
 {
 	/**
-	 * @var    JRegistry  Options for the Linkedin object.
+	 * @var    array  Options for the Linkedin object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -44,37 +43,37 @@ class Linkedin
 	protected $oauth;
 
 	/**
-	 * @var    JLinkedinPeople  Linkedin API object for people.
+	 * @var    People  Linkedin API object for people.
 	 * @since  1.0
 	 */
 	protected $people;
 
 	/**
-	 * @var    JLinkedinGroups  Linkedin API object for groups.
+	 * @var    Groups  Linkedin API object for groups.
 	 * @since  1.0
 	 */
 	protected $groups;
 
 	/**
-	 * @var    JLinkedinCompanies  Linkedin API object for companies.
+	 * @var    Companies  Linkedin API object for companies.
 	 * @since  1.0
 	 */
 	protected $companies;
 
 	/**
-	 * @var    JLinkedinJobs  Linkedin API object for jobs.
+	 * @var    Jobs  Linkedin API object for jobs.
 	 * @since  1.0
 	 */
 	protected $jobs;
 
 	/**
-	 * @var    JLinkedinStream  Linkedin API object for social stream.
+	 * @var    Stream  Linkedin API object for social stream.
 	 * @since  1.0
 	 */
 	protected $stream;
 
 	/**
-	 * @var    JLinkedinCommunications  Linkedin API object for communications.
+	 * @var    Communications  Linkedin API object for communications.
 	 * @since  1.0
 	 */
 	protected $communications;
@@ -82,20 +81,23 @@ class Linkedin
 	/**
 	 * Constructor.
 	 *
-	 * @param   OAuth     $oauth    The Linkedin OAuth client.
-	 * @param   Registry  $options  Linkedin options object.
-	 * @param   Http      $client   The HTTP client object.
+	 * @param   OAuth  $oauth    The Linkedin OAuth client.
+	 * @param   array  $options  Linkedin options array.
+	 * @param   Http   $client   The HTTP client object.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(OAuth $oauth = null, Registry $options = null, Http $client = null)
+	public function __construct(OAuth $oauth = null, $options = array(), Http $client = null)
 	{
 		$this->oauth = $oauth;
-		$this->options = isset($options) ? $options : new Registry;
-		$this->client  = isset($client) ? $client : new Http($this->options);
+		$this->options = $options;
+		$this->client  = $client;
 
 		// Setup the default API url if not already set.
-		$this->options->def('api.url', 'https://api.linkedin.com');
+		if (!isset($this->options['api.url']))
+		{
+			$this->options['api.url'] = 'https://api.linkedin.com';
+		}
 	}
 
 	/**
@@ -110,9 +112,9 @@ class Linkedin
 	 */
 	public function __get($name)
 	{
-		$class = '\\Joomla\\Linkedin\\' . ucfirst($name);
+		$class = __NAMESPACE__ . '\\' . ucfirst(strtolower($name));
 
-		if (class_exists($class))
+		if (class_exists($class) && property_exists($this, $name))
 		{
 			if (false == isset($this->$name))
 			{
@@ -136,7 +138,7 @@ class Linkedin
 	 */
 	public function getOption($key)
 	{
-		return $this->options->get($key);
+		return isset($this->options[$key]) ? $this->options[$key] : null;
 	}
 
 	/**
@@ -151,7 +153,7 @@ class Linkedin
 	 */
 	public function setOption($key, $value)
 	{
-		$this->options->set($key, $value);
+		$this->options[$key] = $value;
 
 		return $this;
 	}

--- a/src/Joomla/Linkedin/Object.php
+++ b/src/Joomla/Linkedin/Object.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Linkedin;
 
-use Joomla\Registry\Registry;
 use Joomla\Http\Http;
 use Joomla\Linkedin\OAuth;
 
@@ -20,7 +19,7 @@ use Joomla\Linkedin\OAuth;
 abstract class Object
 {
 	/**
-	 * @var    Registry  Options for the Linkedin object.
+	 * @var    array  Options for the Linkedin object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -40,15 +39,15 @@ abstract class Object
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry  $options  Linkedin options object.
-	 * @param   Http      $client   The HTTP client object.
-	 * @param   OAuth     $oauth    The OAuth client.
+	 * @param   array  $options  Linkedin options array.
+	 * @param   Http   $client   The HTTP client object.
+	 * @param   OAuth  $oauth    The OAuth client.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options = null, Http $client = null, OAuth $oauth = null)
+	public function __construct($options = array(), Http $client = null, OAuth $oauth = null)
 	{
-		$this->options = isset($options) ? $options : new Registry;
+		$this->options = $options;
 		$this->client = isset($client) ? $client : new Http($this->options);
 		$this->oauth = $oauth;
 	}
@@ -85,7 +84,7 @@ abstract class Object
 	 */
 	public function getOption($key)
 	{
-		return $this->options->get($key);
+		return isset($this->options[$key]) ? $this->options[$key] : null;
 	}
 
 	/**
@@ -100,7 +99,7 @@ abstract class Object
 	 */
 	public function setOption($key, $value)
 	{
-		$this->options->set($key, $value);
+		$this->options[$key] = $value;
 
 		return $this;
 	}

--- a/src/Joomla/Linkedin/Tests/LinkedinTest.php
+++ b/src/Joomla/Linkedin/Tests/LinkedinTest.php
@@ -6,6 +6,7 @@
 
 namespace Joomla\Linkedin\Tests;
 
+use Joomla\Test\TestHelper;
 use Joomla\Linkedin\Linkedin;
 use Joomla\Linkedin\People;
 use Joomla\Linkedin\Groups;
@@ -151,8 +152,10 @@ class LinkedinTest extends LinkedinTestCase
 	{
 		$this->object->setOption('api.url', 'https://example.com/settest');
 
+		$value = TestHelper::getValue($this->object, 'options');
+
 		$this->assertThat(
-			$this->options->get('api.url'),
+			$value['api.url'],
 			$this->equalTo('https://example.com/settest')
 		);
 	}
@@ -166,10 +169,12 @@ class LinkedinTest extends LinkedinTestCase
 	 */
 	public function testGetOption()
 	{
-		$this->options->set('api.url', 'https://example.com/gettest');
+		TestHelper::setValue($this->object, 'options', array(
+				'api.url' => 'https://example.com/gettest'
+			));
 
 		$this->assertThat(
-			$this->object->getOption('api.url', 'https://example.com/gettest'),
+			$this->object->getOption('api.url'),
 			$this->equalTo('https://example.com/gettest')
 		);
 	}

--- a/src/Joomla/Oauth1/Client.php
+++ b/src/Joomla/Oauth1/Client.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Oauth1;
 
-use Joomla\Registry\Registry;
 use Joomla\Http\Http;
 use Joomla\Input\Input;
 use Joomla\Application\AbstractWebApplication;
@@ -21,7 +20,7 @@ use Joomla\Application\AbstractWebApplication;
 abstract class Client
 {
 	/**
-	 * @var    Registry  Options for the Client object.
+	 * @var    array  Options for the Client object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -59,7 +58,7 @@ abstract class Client
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry                $options      OAuth1 Client options object.
+	 * @param   array                   $options      OAuth1 Client options array.
 	 * @param   Http                    $client       The HTTP client object.
 	 * @param   Input                   $input        The input object
 	 * @param   AbstractWebApplication  $application  The application object
@@ -67,7 +66,7 @@ abstract class Client
 	 *
 	 * @since 1.0
 	 */
-	public function __construct(Registry $options, Http $client, Input $input, AbstractWebApplication $application, $version = '1.0a')
+	public function __construct($options = array(), Http $client, Input $input, AbstractWebApplication $application, $version = '1.0a')
 	{
 		$this->options = $options;
 		$this->client = $client;
@@ -559,7 +558,7 @@ abstract class Client
 	 */
 	public function getOption($key)
 	{
-		return $this->options->get($key);
+		return isset($this->options[$key]) ? $this->options[$key] : null;
 	}
 
 	/**
@@ -574,7 +573,7 @@ abstract class Client
 	 */
 	public function setOption($key, $value)
 	{
-		$this->options->set($key, $value);
+		$this->options[$key] = $value;
 
 		return $this;
 	}

--- a/src/Joomla/Oauth2/Client.php
+++ b/src/Joomla/Oauth2/Client.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Oauth2;
 
-use Joomla\Registry\Registry;
 use Joomla\Application\AbstractWebApplication;
 use Joomla\Input\Input;
 use Joomla\Http\Http;
@@ -21,7 +20,7 @@ use Joomla\Http\Http;
 class Client
 {
 	/**
-	 * @var    Registry  Options for the Client object.
+	 * @var    array  Options for the Client object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -47,14 +46,14 @@ class Client
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry                $options      OAuth2 Client options object
+	 * @param   array                   $options      OAuth2 Client options array
 	 * @param   Http                    $http         The HTTP client object
 	 * @param   Input                   $input        The input object
 	 * @param   AbstractWebApplication  $application  The application object
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options, Http $http, Input $input, AbstractWebApplication $application)
+	public function __construct($options, Http $http, Input $input, AbstractWebApplication $application)
 	{
 		$this->options = $options;
 		$this->http = $http;
@@ -277,7 +276,7 @@ class Client
 	 */
 	public function getOption($key)
 	{
-		return $this->options->get($key);
+		return isset($this->options[$key]) ? $this->options[$key] : null;
 	}
 
 	/**
@@ -292,7 +291,7 @@ class Client
 	 */
 	public function setOption($key, $value)
 	{
-		$this->options->set($key, $value);
+		$this->options[$key] = $value;
 
 		return $this;
 	}

--- a/src/Joomla/Twitter/Block.php
+++ b/src/Joomla/Twitter/Block.php
@@ -8,9 +8,6 @@
 
 namespace Joomla\Twitter;
 
-use Joomla\Twitter\Object;
-use \RuntimeException;
-
 /**
  * Twitter API Block class for the Joomla Framework.
  *
@@ -67,7 +64,7 @@ class Block extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function blockUser($user, $entities = null, $skip_status = null)
 	{
@@ -86,7 +83,7 @@ class Block extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Check if entities is specified
@@ -119,7 +116,7 @@ class Block extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function unblock($user, $entities = null, $skip_status = null)
 	{
@@ -138,7 +135,7 @@ class Block extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Check if entities is specified

--- a/src/Joomla/Twitter/Directmessages.php
+++ b/src/Joomla/Twitter/Directmessages.php
@@ -8,9 +8,6 @@
 
 namespace Joomla\Twitter;
 
-use Joomla\Twitter\Object;
-use \RuntimeException;
-
 /**
  * Twitter API Direct Messages class for the Joomla Framework.
  *
@@ -39,6 +36,8 @@ class Directmessages extends Object
 
 		// Set the API path
 		$path = '/direct_messages.json';
+
+		$data = array();
 
 		// Check if since_id is specified.
 		if ($since_id)
@@ -96,6 +95,8 @@ class Directmessages extends Object
 		// Set the API path
 		$path = '/direct_messages/sent.json';
 
+		$data = array();
+
 		// Check if since_id is specified.
 		if ($since_id)
 		{
@@ -139,7 +140,7 @@ class Directmessages extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function sendDirectMessages($user, $text)
 	{
@@ -158,7 +159,7 @@ class Directmessages extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		$data['text'] = $text;

--- a/src/Joomla/Twitter/Favorites.php
+++ b/src/Joomla/Twitter/Favorites.php
@@ -8,8 +8,6 @@
 
 namespace Joomla\Twitter;
 
-use Joomla\Twitter\Object;
-
 /**
  * Twitter API Favorites class for the Joomla Framework.
  *

--- a/src/Joomla/Twitter/Friends.php
+++ b/src/Joomla/Twitter/Friends.php
@@ -8,9 +8,6 @@
 
 namespace Joomla\Twitter;
 
-use Joomla\Twitter\Object;
-use \RuntimeException;
-
 /**
  * Twitter API Friends class for the Joomla Framework.
  *
@@ -31,7 +28,7 @@ class Friends extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getFriendIds($user, $cursor = null, $string_ids = null, $count = 0)
 	{
@@ -50,7 +47,7 @@ class Friends extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Check if cursor is specified
@@ -87,7 +84,7 @@ class Friends extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getFriendshipDetails($user_a, $user_b)
 	{
@@ -106,7 +103,7 @@ class Friends extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The first specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The first specified username is not in the correct format; must use integer or string');
 		}
 
 		// Determine which type of data was passed for $user_b
@@ -121,7 +118,7 @@ class Friends extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The second specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The second specified username is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path
@@ -144,7 +141,7 @@ class Friends extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getFollowerIds($user, $cursor = null, $string_ids = null, $count = 0)
 	{
@@ -163,7 +160,7 @@ class Friends extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path
@@ -276,7 +273,7 @@ class Friends extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function follow($user, $follow = false)
 	{
@@ -292,7 +289,7 @@ class Friends extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Check if follow is true
@@ -316,7 +313,7 @@ class Friends extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function unfollow($user)
 	{
@@ -332,7 +329,7 @@ class Friends extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path
@@ -351,12 +348,14 @@ class Friends extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getFriendshipsLookup($screen_name = null, $id = null)
 	{
 		// Check the rate limit for remaining hits
 		$this->checkRateLimit('friendships', 'lookup');
+
+		$data = array();
 
 		// Set user IDs and screen names.
 		if ($id)
@@ -372,7 +371,7 @@ class Friends extends Object
 		if ($id == null && $screen_name == null)
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('You must specify either a comma separated list of screen names, user IDs, or a combination of the two');
+			throw new \RuntimeException('You must specify either a comma separated list of screen names, user IDs, or a combination of the two');
 		}
 
 		// Set the API path
@@ -392,7 +391,7 @@ class Friends extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function updateFriendship($user, $device = null, $retweets = null)
 	{
@@ -408,7 +407,7 @@ class Friends extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Check if device is specified.

--- a/src/Joomla/Twitter/Help.php
+++ b/src/Joomla/Twitter/Help.php
@@ -8,8 +8,6 @@
 
 namespace Joomla\Twitter;
 
-use Joomla\Twitter\Object;
-
 /**
  * Twitter API Help class for the Joomla Framework.
  *

--- a/src/Joomla/Twitter/Lists.php
+++ b/src/Joomla/Twitter/Lists.php
@@ -8,9 +8,6 @@
 
 namespace Joomla\Twitter;
 
-use Joomla\Twitter\Object;
-use \RuntimeException;
-
 /**
  * Twitter API Lists class for the Joomla Framework.
  *
@@ -28,7 +25,7 @@ class Lists extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getLists($user, $reverse = null)
 	{
@@ -47,7 +44,7 @@ class Lists extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Check if reverse is specified.
@@ -79,7 +76,7 @@ class Lists extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getStatuses($list, $owner = null, $since_id = 0, $max_id = 0, $count = 0, $entities = null, $include_rts = null)
 	{
@@ -107,13 +104,13 @@ class Lists extends Object
 			else
 			{
 				// We don't have a valid entry
-				throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+				throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 			}
 		}
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified list is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified list is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path
@@ -166,7 +163,7 @@ class Lists extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getSubscribers($list, $owner = null, $cursor = null, $entities = null, $skip_status = null)
 	{
@@ -194,13 +191,13 @@ class Lists extends Object
 			else
 			{
 				// We don't have a valid entry
-				throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+				throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 			}
 		}
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified list is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified list is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path
@@ -239,7 +236,7 @@ class Lists extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function deleteMembers($list, $user_id = null, $screen_name = null, $owner = null)
 	{
@@ -264,13 +261,13 @@ class Lists extends Object
 			else
 			{
 				// We don't have a valid entry
-				throw new RuntimeException('The specified username for owner is not in the correct format; must use integer or string');
+				throw new \RuntimeException('The specified username for owner is not in the correct format; must use integer or string');
 			}
 		}
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified list is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified list is not in the correct format; must use integer or string');
 		}
 
 		if ($user_id)
@@ -286,7 +283,7 @@ class Lists extends Object
 		if ($user_id == null && $screen_name == null)
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('You must specify either a comma separated list of screen names, user IDs, or a combination of the two');
+			throw new \RuntimeException('You must specify either a comma separated list of screen names, user IDs, or a combination of the two');
 		}
 
 		// Set the API path
@@ -305,7 +302,7 @@ class Lists extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function subscribe($list, $owner = null)
 	{
@@ -333,13 +330,13 @@ class Lists extends Object
 			else
 			{
 				// We don't have a valid entry
-				throw new RuntimeException('The specified username for owner is not in the correct format; must use integer or string');
+				throw new \RuntimeException('The specified username for owner is not in the correct format; must use integer or string');
 			}
 		}
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified list is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified list is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path
@@ -362,7 +359,7 @@ class Lists extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function isMember($list, $user, $owner = null, $entities = null, $skip_status = null)
 	{
@@ -390,13 +387,13 @@ class Lists extends Object
 			else
 			{
 				// We don't have a valid entry
-				throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+				throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 			}
 		}
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified list is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified list is not in the correct format; must use integer or string');
 		}
 
 		if (is_numeric($user))
@@ -410,7 +407,7 @@ class Lists extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path
@@ -445,7 +442,7 @@ class Lists extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function isSubscriber($list, $user, $owner = null, $entities = null, $skip_status = null)
 	{
@@ -473,13 +470,13 @@ class Lists extends Object
 			else
 			{
 				// We don't have a valid entry
-				throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+				throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 			}
 		}
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified list is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified list is not in the correct format; must use integer or string');
 		}
 
 		if (is_numeric($user))
@@ -493,7 +490,7 @@ class Lists extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path
@@ -524,7 +521,7 @@ class Lists extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function unsubscribe($list, $owner = null)
 	{
@@ -552,13 +549,13 @@ class Lists extends Object
 			else
 			{
 				// We don't have a valid entry
-				throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+				throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 			}
 		}
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified list is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified list is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path
@@ -579,7 +576,7 @@ class Lists extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function addMembers($list, $user_id = null, $screen_name = null, $owner = null)
 	{
@@ -607,13 +604,13 @@ class Lists extends Object
 			else
 			{
 				// We don't have a valid entry
-				throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+				throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 			}
 		}
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified list is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified list is not in the correct format; must use integer or string');
 		}
 
 		if ($user_id)
@@ -629,7 +626,7 @@ class Lists extends Object
 		if ($user_id == null && $screen_name == null)
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('You must specify either a comma separated list of screen names, user IDs, or a combination of the two');
+			throw new \RuntimeException('You must specify either a comma separated list of screen names, user IDs, or a combination of the two');
 		}
 
 		// Set the API path
@@ -651,7 +648,7 @@ class Lists extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getMembers($list, $owner = null, $entities = null, $skip_status = null)
 	{
@@ -679,13 +676,13 @@ class Lists extends Object
 			else
 			{
 				// We don't have a valid entry
-				throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+				throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 			}
 		}
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified list is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified list is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path
@@ -716,7 +713,7 @@ class Lists extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getListById($list, $owner = null)
 	{
@@ -744,13 +741,13 @@ class Lists extends Object
 			else
 			{
 				// We don't have a valid entry
-				throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+				throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 			}
 		}
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified list is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified list is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path
@@ -770,7 +767,7 @@ class Lists extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getSubscriptions($user, $count = 0, $cursor = null)
 	{
@@ -789,7 +786,7 @@ class Lists extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Check if count is specified.
@@ -824,7 +821,7 @@ class Lists extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function update($list, $owner = null, $name = null, $mode = null, $description = null)
 	{
@@ -852,13 +849,13 @@ class Lists extends Object
 			else
 			{
 				// We don't have a valid entry
-				throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+				throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 			}
 		}
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified list is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified list is not in the correct format; must use integer or string');
 		}
 
 		// Check if name is specified.
@@ -903,6 +900,8 @@ class Lists extends Object
 		// Check the rate limit for remaining hits
 		$this->checkRateLimit('lists', 'create');
 
+		$data = array();
+
 		// Check if name is specified.
 		if ($name)
 		{
@@ -937,7 +936,7 @@ class Lists extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function delete($list, $owner = null)
 	{
@@ -965,13 +964,13 @@ class Lists extends Object
 			else
 			{
 				// We don't have a valid entry
-				throw new RuntimeException('The specified username for owner is not in the correct format; must use integer or string');
+				throw new \RuntimeException('The specified username for owner is not in the correct format; must use integer or string');
 			}
 		}
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified list is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified list is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path

--- a/src/Joomla/Twitter/OAuth.php
+++ b/src/Joomla/Twitter/OAuth.php
@@ -9,7 +9,6 @@
 namespace Joomla\Twitter;
 
 use Joomla\Oauth1\Client;
-use Joomla\Registry\Registry;
 use Joomla\Http\Http;
 use Joomla\Input\Input;
 use Joomla\Application\AbstractWebApplication;
@@ -22,7 +21,7 @@ use Joomla\Application\AbstractWebApplication;
 class OAuth extends Client
 {
 	/**
-	 * @var    Registry Options for the Twitter Oauth object.
+	 * @var    array  Options for the Twitter OAuth object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -30,21 +29,36 @@ class OAuth extends Client
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry                $options      JTwitterOauth options object.
+	 * @param   array                   $options      OAuth options array.
 	 * @param   Http                    $client       The HTTP client object.
 	 * @param   Input                   $input        The input object.
 	 * @param   AbstractWebApplication  $application  The application object.
 	 *
 	 * @since 1.0
 	 */
-	public function __construct(Registry $options, Http $client, Input $input, AbstractWebApplication $application)
+	public function __construct($options = array(), Http $client, Input $input, AbstractWebApplication $application)
 	{
 		$this->options = $options;
 
-		$this->options->def('accessTokenURL', 'https://api.twitter.com/oauth/access_token');
-		$this->options->def('authenticateURL', 'https://api.twitter.com/oauth/authenticate');
-		$this->options->def('authoriseURL', 'https://api.twitter.com/oauth/authorize');
-		$this->options->def('requestTokenURL', 'https://api.twitter.com/oauth/request_token');
+		if (!isset($this->options['accessTokenURL']))
+		{
+			$this->options['accessTokenURL'] = 'https://api.twitter.com/oauth/access_token';
+		}
+
+		if (!isset($this->options['authenticateURL']))
+		{
+			$this->options['authenticateURL'] = 'https://api.twitter.com/oauth/authenticate';
+		}
+
+		if (!isset($this->options['authoriseURL']))
+		{
+			$this->options['authoriseURL'] = 'https://api.twitter.com/oauth/authorize';
+		}
+
+		if (!isset($this->options['requestTokenURL']))
+		{
+			$this->options['requestTokenURL'] = 'https://api.twitter.com/oauth/request_token';
+		}
 
 		// Call the OAuth1 Client constructor to setup the object.
 		parent::__construct($this->options, $client, $input, $application);

--- a/src/Joomla/Twitter/Object.php
+++ b/src/Joomla/Twitter/Object.php
@@ -8,11 +8,8 @@
 
 namespace Joomla\Twitter;
 
-use Joomla\Registry\Registry;
-use Joomla\Http\Http;
-use Joomla\Twitter\OAuth;
 use Joomla\Uri\Uri;
-use \RuntimeException;
+use Joomla\Http\Http;
 
 /**
  * Twitter API object class for the Joomla Framework.
@@ -22,7 +19,7 @@ use \RuntimeException;
 abstract class Object
 {
 	/**
-	 * @var    Registry  Options for the Twitter object.
+	 * @var    array  Options for the Twitter object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -42,16 +39,16 @@ abstract class Object
 	/**
 	 * Constructor.
 	 *
-	 * @param   Registry  &$options  Twitter options object.
-	 * @param   Http      $client    The HTTP client object.
-	 * @param   OAuth     $oauth     The OAuth client.
+	 * @param   array  &$options  Twitter options array.
+	 * @param   Http   $client    The HTTP client object.
+	 * @param   OAuth  $oauth     The OAuth client.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry &$options = null, Http $client = null, OAuth $oauth = null)
+	public function __construct(&$options = array(), Http $client, OAuth $oauth)
 	{
-		$this->options = isset($options) ? $options : new Registry;
-		$this->client = isset($client) ? $client : new Http($this->options);
+		$this->options = $options;
+		$this->client = $client;
 		$this->oauth = $oauth;
 	}
 
@@ -64,7 +61,7 @@ abstract class Object
 	 * @return  void
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function checkRateLimit($resource = null, $action = null)
 	{
@@ -81,7 +78,7 @@ abstract class Object
 		if ($rate_limit->resources->$resource->$property->remaining == 0)
 		{
 			// The IP has exceeded the Twitter API rate limit
-			throw new RuntimeException('This server has exceed the Twitter API rate limit for the given period.  The limit will reset at '
+			throw new \RuntimeException('This server has exceed the Twitter API rate limit for the given period.  The limit will reset at '
 						. $rate_limit->resources->$resource->$property->reset
 			);
 		}
@@ -116,10 +113,11 @@ abstract class Object
 			}
 		}
 
-		// Get a new JUri object fousing the api url and given path.
+		// Get a new Uri object using the api url and given path.
 		if (strpos($path, 'http://search.twitter.com/search.json') === false)
 		{
-			$uri = new Uri($this->options->get('api.url') . $path);
+			$apiUrl = isset($this->options['api.url']) ? $this->options['api.url'] : null;
+			$uri = new Uri($apiUrl . $path);
 		}
 		else
 		{
@@ -182,7 +180,7 @@ abstract class Object
 			if ($response_headers['x-mediaratelimit-remaining'] == 0)
 			{
 				// The IP has exceeded the Twitter API media rate limit
-				throw new RuntimeException('This server has exceed the Twitter API media rate limit for the given period.  The limit will reset in '
+				throw new \RuntimeException('This server has exceed the Twitter API media rate limit for the given period.  The limit will reset in '
 						. $response_headers['x-mediaratelimit-reset'] . 'seconds.'
 				);
 			}
@@ -207,7 +205,7 @@ abstract class Object
 	 */
 	public function getOption($key)
 	{
-		return $this->options->get($key);
+		return isset($this->options[$key]) ? $this->options[$key] : null;
 	}
 
 	/**
@@ -222,7 +220,7 @@ abstract class Object
 	 */
 	public function setOption($key, $value)
 	{
-		$this->options->set($key, $value);
+		$this->options[$key] = $value;
 
 		return $this;
 	}

--- a/src/Joomla/Twitter/Places.php
+++ b/src/Joomla/Twitter/Places.php
@@ -8,9 +8,6 @@
 
 namespace Joomla\Twitter;
 
-use Joomla\Twitter\Object;
-use \RuntimeException;
-
 /**
  * Twitter API Places & Geo class for the Joomla Framework.
  *
@@ -115,7 +112,7 @@ class Places extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function search($lat = null, $long = null, $query = null, $ip = null, $granularity = null, $accuracy = null, $max_results = 0,
 		$within = null, $attribute = null, $callback = null)
@@ -129,7 +126,7 @@ class Places extends Object
 		// At least one of the following parameters must be provided: lat, long, ip, or query.
 		if ($lat == null && $long == null && $ip == null && $query == null)
 		{
-			throw new RuntimeException('At least one of the following parameters must be provided: lat, long, ip, or query.');
+			throw new \RuntimeException('At least one of the following parameters must be provided: lat, long, ip, or query.');
 		}
 
 		// Check if lat is specified.

--- a/src/Joomla/Twitter/Profile.php
+++ b/src/Joomla/Twitter/Profile.php
@@ -8,8 +8,6 @@
 
 namespace Joomla\Twitter;
 
-use Joomla\Twitter\Object;
-
 /**
  * Twitter API Profile class for the Joomla Framework.
  *

--- a/src/Joomla/Twitter/README.md
+++ b/src/Joomla/Twitter/README.md
@@ -18,18 +18,19 @@ This creates a basic Twitter object that can be used to access resources on twit
 
 Generating an access token can be done by instantiating OAuth.
 
-Create a Twitter application at [https://dev.twitter.com/apps](https://dev.twitter.com/apps) in order to request permissions. Instantiate OAuth, passing the Registry options needed. By default you have to set and send headers manually in your application, but if you want this to be done automatically you can set Registry option 'sendheaders' to true.
+Create a Twitter application at [https://dev.twitter.com/apps](https://dev.twitter.com/apps) in order to request permissions. Instantiate OAuth, passing the options needed. By default you have to set and send headers manually in your application, but if you want this to be done automatically you can set option 'sendheaders' to true.
 
 ```php
 use Joomla\Twitter\Twitter;
 use Joomla\Twitter\OAuth;
-use Joomla\Registry\Registry;
 
-$options = new Registry;
-$options->set('consumer_key', $consumer_key);
-$options->set('consumer_secret', $consumer_secret);
-$options->set('callback', $callback_url);
-$options->set('sendheaders', true);
+$options = array(
+    'consumer_key' => $consumer_key,
+    'consumer_secret' => $consumer_secret,
+    'callback' => $callback_url,
+    'sendheaders' => true
+);
+
 $oauth = new OAuth($options);
 
 $twitter = new Twitter($oauth);
@@ -77,18 +78,17 @@ Below is an example demonstrating more of the Twitter package.
 ```php
 use Joomla\Twitter\Twitter;
 use Joomla\Twitter\OAuth;
-use Joomla\Registry\Registry;
 
 $app_id = "app_id";
 $app_secret = "app_secret";
 $my_url = 'http://localhost/twitter_test.php';
 
-
-$options = new Registry;
-$options->set('consumer_key', $key);
-$options->set('consumer_secret', $secret);
-$options->set('callback', $my_url);
-$options->set('sendheaders', true);
+$options = array(
+    'consumer_key' => $consumer_key,
+    'consumer_secret' => $consumer_secret,
+    'callback' => $callback_url,
+    'sendheaders' => true
+);
 
 $oauth = new OAuth($options);
 $oauth->authenticate();

--- a/src/Joomla/Twitter/Search.php
+++ b/src/Joomla/Twitter/Search.php
@@ -8,8 +8,6 @@
 
 namespace Joomla\Twitter;
 
-use Joomla\Twitter\Object;
-
 /**
  * Twitter API Search class for the Joomla Framework.
  *

--- a/src/Joomla/Twitter/Statuses.php
+++ b/src/Joomla/Twitter/Statuses.php
@@ -8,9 +8,6 @@
 
 namespace Joomla\Twitter;
 
-use Joomla\Twitter\Object;
-use \RuntimeException;
-
 /**
  * Twitter API Statuses class for the Joomla Framework.
  *
@@ -84,7 +81,7 @@ class Statuses extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getUserTimeline($user, $count = 20, $include_rts = null, $no_replies = null, $since_id = 0, $max_id = 0, $trim_user = null,
 		$contributor = null)
@@ -106,7 +103,7 @@ class Statuses extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Set the API base
@@ -238,7 +235,7 @@ class Statuses extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getMentions($count = 20, $include_rts = null, $entities = null, $since_id = 0, $max_id = 0,
 		$trim_user = null, $contributor = null)
@@ -504,7 +501,7 @@ class Statuses extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function tweetWithMedia($status, $media, $in_reply_to_status_id = null, $lat = null, $long = null, $place_id = null,
 		$display_coordinates = null, $sensitive = null)
@@ -583,7 +580,7 @@ class Statuses extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getOembed($id = null, $url = null, $maxwidth = null, $hide_media = null, $hide_thread = null, $omit_script = null,
 		$align = null, $related = null, $lang = null)
@@ -606,7 +603,7 @@ class Statuses extends Object
 		else
 		{
 			// We don't have a valid entry.
-			throw new RuntimeException('Either the id or url parameters must be specified in a request.');
+			throw new \RuntimeException('Either the id or url parameters must be specified in a request.');
 		}
 
 		// Check if maxwidth is specified.

--- a/src/Joomla/Twitter/Tests/ObjectTest.php
+++ b/src/Joomla/Twitter/Tests/ObjectTest.php
@@ -6,6 +6,7 @@
 
 namespace Joomla\Twitter\Tests;
 
+use Joomla\Test\TestHelper;
 use Joomla\Twitter\Object;
 use \stdClass;
 
@@ -46,7 +47,7 @@ class ObjectTest extends TwitterTestCase
 	 * @return void
 	 *
 	 * @since 1.0
-	 * @expectedException RuntimeException
+	 * @expectedException \RuntimeException
 	 */
 	public function testCheckRateLimit()
 	{
@@ -159,8 +160,10 @@ class ObjectTest extends TwitterTestCase
 	{
 		$this->object->setOption('api.url', 'https://example.com/settest');
 
+		$value = TestHelper::getValue($this->object, 'options');
+
 		$this->assertThat(
-			$this->options->get('api.url'),
+			$value['api.url'],
 			$this->equalTo('https://example.com/settest')
 		);
 	}
@@ -174,11 +177,13 @@ class ObjectTest extends TwitterTestCase
 	 */
 	public function testGetOption()
 	{
-		$this->options->set('api.url', 'https://example.com/settest');
+		TestHelper::setValue($this->object, 'options', array(
+				'api.url' => 'https://example.com/gettest'
+			));
 
 		$this->assertThat(
-				$this->object->getOption('api.url'),
-				$this->equalTo('https://example.com/settest')
+			$this->object->getOption('api.url'),
+			$this->equalTo('https://example.com/gettest')
 		);
 	}
 }

--- a/src/Joomla/Twitter/Tests/TwitterTest.php
+++ b/src/Joomla/Twitter/Tests/TwitterTest.php
@@ -6,6 +6,7 @@
 
 namespace Joomla\Twitter\Tests;
 
+use Joomla\Test\TestHelper;
 use Joomla\Twitter\Twitter;
 use Joomla\Twitter\Block;
 use Joomla\Twitter\Directmessages;
@@ -249,8 +250,10 @@ class TwitterTest extends TwitterTestCase
 	{
 		$this->object->setOption('api.url', 'https://example.com/settest');
 
+		$value = TestHelper::getValue($this->object, 'options');
+
 		$this->assertThat(
-			$this->options->get('api.url'),
+			$value['api.url'],
 			$this->equalTo('https://example.com/settest')
 		);
 	}
@@ -264,10 +267,12 @@ class TwitterTest extends TwitterTestCase
 	 */
 	public function testGetOption()
 	{
-		$this->options->set('api.url', 'https://example.com/gettest');
+		TestHelper::setValue($this->object, 'options', array(
+				'api.url' => 'https://example.com/gettest'
+			));
 
 		$this->assertThat(
-			$this->object->getOption('api.url', 'https://example.com/gettest'),
+			$this->object->getOption('api.url'),
 			$this->equalTo('https://example.com/gettest')
 		);
 	}

--- a/src/Joomla/Twitter/Tests/case/TwitterTestCase.php
+++ b/src/Joomla/Twitter/Tests/case/TwitterTestCase.php
@@ -6,7 +6,6 @@
 
 namespace Joomla\Twitter\Tests;
 
-use Joomla\Registry\Registry;
 use Joomla\Http\Http;
 use Joomla\Input\Input;
 use Joomla\Twitter\OAuth;
@@ -20,7 +19,7 @@ use Joomla\Test\WebInspector;
 class TwitterTestCase extends \PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    Registry  Options for the Linkedin object.
+	 * @var    array  Options for the object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -50,7 +49,7 @@ class TwitterTestCase extends \PHPUnit_Framework_TestCase
 	protected $oauth;
 
 	/**
-	 * @var    Linkedin  Object under test (companies, groups, jobs ..).
+	 * @var    object  Object under test (companies, groups, jobs ..).
 	 * @since  1.0
 	 */
 	protected $object;
@@ -82,17 +81,18 @@ class TwitterTestCase extends \PHPUnit_Framework_TestCase
 
 		$access_token = array('key' => 'token_key', 'secret' => 'token_secret');
 
-		$this->options = new Registry;
+		$this->options = array();
+
+		$this->options['consumer_key'] = $key;
+		$this->options['consumer_secret'] = $secret;
+		$this->options['callback'] = $my_url;
+		$this->options['sendheaders'] = true;
+
 		$this->input = new Input;
-		$this->client = $this->getMock('\\Joomla\\Http\\Http', array('get', 'post', 'delete', 'put'));
+		$this->client = $this->getMock('Joomla\\Http\\Http', array('get', 'post', 'delete', 'put'));
 		$this->application = new WebInspector;
 		$this->oauth = new OAuth($this->options, $this->client, $this->input, $this->application);
 		$this->oauth->setToken($access_token);
-
-		$this->options->set('consumer_key', $key);
-		$this->options->set('consumer_secret', $secret);
-		$this->options->set('callback', $my_url);
-		$this->options->set('sendheaders', true);
 	}
 
 	/**

--- a/src/Joomla/Twitter/Trends.php
+++ b/src/Joomla/Twitter/Trends.php
@@ -8,8 +8,6 @@
 
 namespace Joomla\Twitter;
 
-use Joomla\Twitter\Object;
-
 /**
  * Twitter API Trends class for the Joomla Framework.
  *

--- a/src/Joomla/Twitter/Twitter.php
+++ b/src/Joomla/Twitter/Twitter.php
@@ -21,7 +21,6 @@ use Joomla\Twitter\Search;
 use Joomla\Twitter\Statuses;
 use Joomla\Twitter\Trends;
 use Joomla\Twitter\Users;
-use Joomla\Registry\Registry;
 use Joomla\Http\Http;
 
 /**
@@ -32,7 +31,7 @@ use Joomla\Http\Http;
 class Twitter
 {
 	/**
-	 * @var    Registry  Options for the Twitter object.
+	 * @var    array  Options for the Twitter object.
 	 * @since  1.0
 	 */
 	protected $options;
@@ -124,20 +123,23 @@ class Twitter
 	/**
 	 * Constructor.
 	 *
-	 * @param   OAuth     $oauth    The oauth client.
-	 * @param   Registry  $options  Twitter options object.
-	 * @param   Http      $client   The HTTP client object.
+	 * @param   OAuth  $oauth    The oauth client.
+	 * @param   array  $options  Twitter options array.
+	 * @param   Http   $client   The HTTP client object.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(OAuth $oauth = null, Registry $options = null, Http $client = null)
+	public function __construct(OAuth $oauth = null, $options = array(), Http $client = null)
 	{
 		$this->oauth = $oauth;
-		$this->options = isset($options) ? $options : new Registry;
-		$this->client  = isset($client) ? $client : new Http($this->options);
+		$this->options = $options;
+		$this->client  = $client;
 
 		// Setup the default API url if not already set.
-		$this->options->def('api.url', 'https://api.twitter.com/1.1');
+		if (!isset($this->options['api.url']))
+		{
+			$this->options['api.url'] = 'https://api.twitter.com/1.1';
+		}
 	}
 
 	/**
@@ -177,7 +179,7 @@ class Twitter
 	 */
 	public function getOption($key)
 	{
-		return $this->options->get($key);
+		return isset($this->options[$key]) ? $this->options[$key] : null;
 	}
 
 	/**
@@ -192,7 +194,7 @@ class Twitter
 	 */
 	public function setOption($key, $value)
 	{
-		$this->options->set($key, $value);
+		$this->options[$key] = $value;
 
 		return $this;
 	}

--- a/src/Joomla/Twitter/Users.php
+++ b/src/Joomla/Twitter/Users.php
@@ -8,9 +8,6 @@
 
 namespace Joomla\Twitter;
 
-use Joomla\Twitter\Object;
-use \RuntimeException;
-
 /**
  * Twitter API Users class for the Joomla Framework.
  *
@@ -29,12 +26,14 @@ class Users extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getUsersLookup($screen_name = null, $id = null, $entities = null)
 	{
 		// Check the rate limit for remaining hits
 		$this->checkRateLimit('users', 'lookup');
+
+		$data = array();
 
 		// Set user IDs and screen names.
 		if ($id)
@@ -50,7 +49,7 @@ class Users extends Object
 		if ($id == null && $screen_name == null)
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('You must specify either a comma separated list of screen names, user IDs, or a combination of the two');
+			throw new \RuntimeException('You must specify either a comma separated list of screen names, user IDs, or a combination of the two');
 		}
 
 		// Set the API path
@@ -95,7 +94,7 @@ class Users extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Send the request.
@@ -114,7 +113,7 @@ class Users extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function searchUsers($query, $page = 0, $count = 0, $entities = null)
 	{
@@ -157,7 +156,7 @@ class Users extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getUser($user, $entities = null)
 	{
@@ -176,7 +175,7 @@ class Users extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path
@@ -202,7 +201,7 @@ class Users extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getContributees($user, $entities = null, $skip_status = null)
 	{
@@ -221,7 +220,7 @@ class Users extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path
@@ -253,7 +252,7 @@ class Users extends Object
 	 * @return  array  The decoded JSON response
 	 *
 	 * @since   1.0
-	 * @throws  RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	public function getContributors($user, $entities = null, $skip_status = null)
 	{
@@ -272,7 +271,7 @@ class Users extends Object
 		else
 		{
 			// We don't have a valid entry
-			throw new RuntimeException('The specified username is not in the correct format; must use integer or string');
+			throw new \RuntimeException('The specified username is not in the correct format; must use integer or string');
 		}
 
 		// Set the API path

--- a/src/Joomla/Twitter/composer.json
+++ b/src/Joomla/Twitter/composer.json
@@ -10,8 +10,10 @@
         "joomla/oauth1": "~1.0",
         "joomla/input": "~1.0",
         "joomla/http": "~1.0",
-        "joomla/uri": "~1.0",
-        "joomla/registry": "~1.0"
+        "joomla/uri": "~1.0"
+    },
+    "suggest": {
+        "joomla/registry": "Registry can be used as an alternative to using an array for the package options."
     },
     "target-dir": "Joomla/Twitter",
     "autoload": {


### PR DESCRIPTION
No where near completion, but this is something that we've been needing to do for a while.

It replaces usage and typehinting for `Registry` with simple array access. This makes our packages more flexible, in that it's no longer required to use the Registry package in order to use the packages. This is another step towards a more de-coupled architecture.

It also contains just some general cleanup.
