### PR TITLE
RFC: NullLogger

### DIFF
--- a/src/Joomla/Application/AbstractApplication.php
+++ b/src/Joomla/Application/AbstractApplication.php
@@ -132,24 +132,12 @@ abstract class AbstractApplication implements LoggerAwareInterface
 	public function getLogger()
 	{
 		// If a logger hasn't been set, use NullLogger
-		if (! $this->hasLogger())
+		if (! ($this->logger instanceof LoggerInterface))
 		{
 			$this->logger = new NullLogger;
 		}
 
 		return $this->logger;
-	}
-
-	/**
-	 * Checks if a logger is available.
-	 *
-	 * @return  boolean
-	 *
-	 * @since   1.0
-	 */
-	public function hasLogger()
-	{
-		return ($this->logger instanceof LoggerInterface);
 	}
 
 	/**

--- a/src/Joomla/Application/AbstractApplication.php
+++ b/src/Joomla/Application/AbstractApplication.php
@@ -12,6 +12,7 @@ use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Joomla Framework Base Application Class
@@ -127,16 +128,16 @@ abstract class AbstractApplication implements LoggerAwareInterface
 	 * @return  LoggerInterface
 	 *
 	 * @since   1.0
-	 * @throws  \UnexpectedValueException
 	 */
 	public function getLogger()
 	{
-		if ($this->hasLogger())
+		// If a logger hasn't been set, use NullLogger
+		if (! $this->hasLogger())
 		{
-			return $this->logger;
+			$this->logger = new NullLogger;
 		}
 
-		throw new \UnexpectedValueException('Logger not set in ' . __CLASS__);
+		return $this->logger;
 	}
 
 	/**

--- a/src/Joomla/Application/AbstractDaemonApplication.php
+++ b/src/Joomla/Application/AbstractDaemonApplication.php
@@ -109,10 +109,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// @codeCoverageIgnoreStart
 		if (!defined('SIGHUP'))
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->error('The PCNTL extension for PHP is not available.');
-			}
+			$this->getLogger()->error('The PCNTL extension for PHP is not available.');
 
 			throw new \RuntimeException('The PCNTL extension for PHP is not available.');
 		}
@@ -120,10 +117,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// Verify that POSIX support for PHP is available.
 		if (!function_exists('posix_getpid'))
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->error('The POSIX extension for PHP is not available.');
-			}
+			$this->getLogger()->error('The POSIX extension for PHP is not available.');
 
 			throw new \RuntimeException('The POSIX extension for PHP is not available.');
 		}
@@ -158,29 +152,13 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 	 */
 	public function signal($signal)
 	{
-		// Retrieve the logger if set
-		try
-		{
-			$logger = $this->getLogger();
-		}
-		catch (\UnexpectedValueException $e)
-		{
-			$logger = false;
-		}
-
 		// Log all signals sent to the daemon.
-		if ($logger)
-		{
-			$logger->debug('Received signal: ' . $signal);
-		}
+		$this->getLogger()->debug('Received signal: ' . $signal);
 
 		// Let's make sure we have an application instance.
 		if (!is_subclass_of($this, __CLASS__))
 		{
-			if ($logger)
-			{
-				$logger->emergency('Cannot find the application instance.');
-			}
+			$this->getLogger()->emergency('Cannot find the application instance.');
 
 			throw new \RuntimeException('Cannot find the application instance.');
 		}
@@ -275,10 +253,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 			// No response so remove the process id file and log the situation.
 			@ unlink($pidFile);
 
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->warning('The process found based on PID file was unresponsive.');
-			}
+			$this->getLogger()->warning('The process found based on PID file was unresponsive.');
 
 			return false;
 		}
@@ -397,10 +372,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// Enable basic garbage collection.
 		gc_enable();
 
-		if ($this->hasLogger())
-		{
-			$this->getLogger()->info('Starting ' . $this->name);
-		}
+		$this->getLogger()->info('Starting ' . $this->name);
 
 		// Set off the process for becoming a daemon.
 		if ($this->daemonize())
@@ -425,10 +397,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		else
 		// We were not able to daemonize the application so log the failure and die gracefully.
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->info('Starting ' . $this->name . ' failed');
-			}
+			$this->getLogger()->info('Starting ' . $this->name . ' failed');
 		}
 
 		// @event onAfterExecute
@@ -444,10 +413,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 	 */
 	public function restart()
 	{
-		if ($this->hasLogger())
-		{
-			$this->getLogger()->info('Stopping ' . $this->name);
-		}
+		$this->getLogger()->info('Stopping ' . $this->name);
 
 		$this->shutdown(true);
 	}
@@ -462,10 +428,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 	 */
 	public function stop()
 	{
-		if ($this->hasLogger())
-		{
-			$this->getLogger()->info('Stopping ' . $this->name);
-		}
+		$this->getLogger()->info('Stopping ' . $this->name);
 
 		$this->shutdown();
 	}
@@ -490,10 +453,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// Change the user id for the process id file if necessary.
 		if ($uid && (fileowner($file) != $uid) && (!@ chown($file, $uid)))
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->error('Unable to change user ownership of the process id file.');
-			}
+			$this->getLogger()->error('Unable to change user ownership of the process id file.');
 
 			return false;
 		}
@@ -501,10 +461,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// Change the group id for the process id file if necessary.
 		if ($gid && (filegroup($file) != $gid) && (!@ chgrp($file, $gid)))
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->error('Unable to change group ownership of the process id file.');
-			}
+			$this->getLogger()->error('Unable to change group ownership of the process id file.');
 
 			return false;
 		}
@@ -518,10 +475,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// Change the user id for the process necessary.
 		if ($uid && (posix_getuid($file) != $uid) && (!@ posix_setuid($uid)))
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->error('Unable to change user ownership of the proccess.');
-			}
+			$this->getLogger()->error('Unable to change user ownership of the proccess.');
 
 			return false;
 		}
@@ -529,10 +483,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// Change the group id for the process necessary.
 		if ($gid && (posix_getgid($file) != $gid) && (!@ posix_setgid($gid)))
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->error('Unable to change group ownership of the proccess.');
-			}
+			$this->getLogger()->error('Unable to change group ownership of the proccess.');
 
 			return false;
 		}
@@ -541,10 +492,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		$user = posix_getpwuid($uid);
 		$group = posix_getgrgid($gid);
 
-		if ($this->hasLogger())
-		{
-			$this->getLogger()->info('Changed daemon identity to ' . $user['name'] . ':' . $group['name']);
-		}
+		$this->getLogger()->info('Changed daemon identity to ' . $user['name'] . ':' . $group['name']);
 
 		return true;
 	}
@@ -562,10 +510,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// Is there already an active daemon running?
 		if ($this->isActive())
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->emergency($this->name . ' daemon is still running. Exiting the application.');
-			}
+			$this->getLogger()->emergency($this->name . ' daemon is still running. Exiting the application.');
 
 			return false;
 		}
@@ -597,10 +542,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		}
 		catch (\RuntimeException $e)
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->emergency('Unable to fork.');
-			}
+			$this->getLogger()->emergency('Unable to fork.');
 
 			return false;
 		}
@@ -608,10 +550,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// Verify the process id is valid.
 		if ($this->processId < 1)
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->emergency('The process id is invalid; the fork failed.');
-			}
+			$this->getLogger()->emergency('The process id is invalid; the fork failed.');
 
 			return false;
 		}
@@ -622,10 +561,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// Write out the process id file for concurrency management.
 		if (!$this->writeProcessIdFile())
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->emergency('Unable to write the pid file at: ' . $this->config->get('application_pid_file'));
-			}
+			$this->getLogger()->emergency('Unable to write the pid file at: ' . $this->config->get('application_pid_file'));
 
 			return false;
 		}
@@ -636,19 +572,13 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 			// If the identity change was required then we need to return false.
 			if ($this->config->get('application_require_identity'))
 			{
-				if ($this->hasLogger())
-				{
-					$this->getLogger()->critical('Unable to change process owner.');
-				}
+				$this->getLogger()->critical('Unable to change process owner.');
 
 				return false;
 			}
 			else
 			{
-				if ($this->hasLogger())
-				{
-					$this->getLogger()->warning('Unable to change process owner.');
-				}
+				$this->getLogger()->warning('Unable to change process owner.');
 			}
 		}
 
@@ -675,10 +605,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 	 */
 	protected function detach()
 	{
-		if ($this->hasLogger())
-		{
-			$this->getLogger()->debug('Detaching the ' . $this->name . ' daemon.');
-		}
+		$this->getLogger()->debug('Detaching the ' . $this->name . ' daemon.');
 
 		// Attempt to fork the process.
 		$pid = $this->fork();
@@ -687,10 +614,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		if ($pid)
 		{
 			// Add the log entry for debugging purposes and exit gracefully.
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->debug('Ending ' . $this->name . ' parent process');
-			}
+			$this->getLogger()->debug('Ending ' . $this->name . ' parent process');
 
 			$this->close();
 		}
@@ -733,10 +657,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// Log the fork in the parent.
 		{
 			// Log the fork.
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->debug('Process forked ' . $pid);
-			}
+			$this->getLogger()->debug('Process forked ' . $pid);
 		}
 
 		// Trigger the onFork event.
@@ -782,10 +703,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 			if (!defined($signal) || !is_int(constant($signal)) || (constant($signal) === 0))
 			{
 				// Define the signal to avoid notices.
-				if ($this->hasLogger())
-				{
-					$this->getLogger()->debug('Signal "' . $signal . '" not defined. Defining it as null.');
-				}
+				$this->getLogger()->debug('Signal "' . $signal . '" not defined. Defining it as null.');
 
 				define($signal, null);
 
@@ -796,10 +714,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 			// Attach the signal handler for the signal.
 			if (!$this->pcntlSignal(constant($signal), array($this, 'signal')))
 			{
-				if ($this->hasLogger())
-				{
-					$this->getLogger()->emergency(sprintf('Unable to reroute signal handler: %s', $signal));
-				}
+				$this->getLogger()->emergency(sprintf('Unable to reroute signal handler: %s', $signal));
 
 				return false;
 			}
@@ -833,10 +748,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// If we aren't already daemonized then just kill the application.
 		if (!$this->running && !$this->isActive())
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->info('Process was not daemonized yet, just halting current process');
-			}
+			$this->getLogger()->info('Process was not daemonized yet, just halting current process');
 
 			$this->close();
 		}
@@ -879,10 +791,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// Verify the process id is valid.
 		if ($this->processId < 1)
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->emergency('The process id is invalid.');
-			}
+			$this->getLogger()->emergency('The process id is invalid.');
 
 			return false;
 		}
@@ -892,10 +801,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 
 		if (empty($file))
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->error('The process id file path is empty.');
-			}
+			$this->getLogger()->error('The process id file path is empty.');
 
 			return false;
 		}
@@ -905,10 +811,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 
 		if (!is_dir($folder) && !Folder::create($folder))
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->error('Unable to create directory: ' . $folder);
-			}
+			$this->getLogger()->error('Unable to create directory: ' . $folder);
 
 			return false;
 		}
@@ -916,10 +819,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// Write the process id file out to disk.
 		if (!file_put_contents($file, $this->processId))
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->error('Unable to write proccess id file: ' . $file);
-			}
+			$this->getLogger()->error('Unable to write proccess id file: ' . $file);
 
 			return false;
 		}
@@ -927,10 +827,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 		// Make sure the permissions for the proccess id file are accurate.
 		if (!chmod($file, 0644))
 		{
-			if ($this->hasLogger())
-			{
-				$this->getLogger()->error('Unable to adjust permissions for the proccess id file: ' . $file);
-			}
+			$this->getLogger()->error('Unable to adjust permissions for the proccess id file: ' . $file);
 
 			return false;
 		}

--- a/src/Joomla/Application/Tests/AbstractApplicationTest.php
+++ b/src/Joomla/Application/Tests/AbstractApplicationTest.php
@@ -140,17 +140,21 @@ class AbstractApplicationTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests the Joomla\Application\AbstractApplication::getLogger for an expected exception.
+	 * Tests the Joomla\Application\AbstractApplication::getLogger for a NullLogger.
 	 *
 	 * @return  void
 	 *
-	 * @covers             Joomla\Application\AbstractApplication::getLogger
-	 * @expectedException  UnexpectedValueException
-	 * @since              1.0
+	 * @since   1.0
 	 */
-	public function testGetLogger_exception()
+	public function testGetNullLogger()
 	{
-		$this->instance->getLogger();
+		$logger = $this->instance->getLogger();
+
+		$this->assertInstanceOf(
+			'Psr\\Log\\NullLogger',
+			$logger,
+			'When a logger has not been set, an instance of NullLogger should be returned.'
+		);
 	}
 
 	/**

--- a/src/Joomla/Application/Tests/AbstractApplicationTest.php
+++ b/src/Joomla/Application/Tests/AbstractApplicationTest.php
@@ -158,24 +158,6 @@ class AbstractApplicationTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests the Joomla\Application\AbstractApplication::hasLogger for an expected exception.
-	 *
-	 * @return  void
-	 *
-	 * @covers  Joomla\Application\AbstractApplication::hasLogger
-	 * @since   1.0
-	 */
-	public function testHasLogger()
-	{
-		$this->assertFalse($this->instance->hasLogger());
-
-		$mockLogger = $this->getMock('Psr\Log\AbstractLogger', array('log'), array(), '', false);
-		$this->instance->setLogger($mockLogger);
-
-		$this->assertTrue($this->instance->hasLogger());
-	}
-
-	/**
 	 * Tests the set method.
 	 *
 	 * @return  void

--- a/src/Joomla/Image/Image.php
+++ b/src/Joomla/Image/Image.php
@@ -129,24 +129,12 @@ class Image implements LoggerAwareInterface
 	public function getLogger()
 	{
 		// If a logger hasn't been set, use NullLogger
-		if (! $this->hasLogger())
+		if (! ($this->logger instanceof LoggerInterface))
 		{
 			$this->logger = new NullLogger;
 		}
 
 		return $this->logger;
-	}
-
-	/**
-	 * Checks if a logger is available.
-	 *
-	 * @return  boolean
-	 *
-	 * @since   1.0
-	 */
-	public function hasLogger()
-	{
-		return ($this->logger instanceof LoggerInterface);
 	}
 
 	/**

--- a/src/Joomla/Image/Image.php
+++ b/src/Joomla/Image/Image.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\Image;
 
+use Psr\Log\NullLogger;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerAwareInterface;
 
@@ -119,17 +120,49 @@ class Image implements LoggerAwareInterface
 	}
 
 	/**
+	 * Get the logger.
+	 *
+	 * @return  LoggerInterface
+	 *
+	 * @since   1.0
+	 */
+	public function getLogger()
+	{
+		// If a logger hasn't been set, use NullLogger
+		if (! $this->hasLogger())
+		{
+			$this->logger = new NullLogger;
+		}
+
+		return $this->logger;
+	}
+
+	/**
+	 * Checks if a logger is available.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   1.0
+	 */
+	public function hasLogger()
+	{
+		return ($this->logger instanceof LoggerInterface);
+	}
+
+	/**
 	 * Sets a logger instance on the object
 	 *
 	 * @param   LoggerInterface  $logger  A PSR-3 compliant logger.
 	 *
-	 * @return  void
+	 * @return  Image  This object for message chaining.
 	 *
 	 * @since   1.0
 	 */
 	public function setLogger(LoggerInterface $logger)
 	{
 		$this->logger = $logger;
+
+		return $this;
 	}
 
 	/**
@@ -557,10 +590,7 @@ class Image implements LoggerAwareInterface
 				if (empty(self::$formats[IMAGETYPE_GIF]))
 				{
 					// @codeCoverageIgnoreStart
-					if ($this->logger)
-					{
-						$this->logger->error('Attempting to load an image of unsupported type GIF.');
-					}
+					$this->getLogger()->error('Attempting to load an image of unsupported type GIF.');
 
 					throw new \RuntimeException('Attempting to load an image of unsupported type GIF.');
 
@@ -586,10 +616,7 @@ class Image implements LoggerAwareInterface
 				if (empty(self::$formats[IMAGETYPE_JPEG]))
 				{
 					// @codeCoverageIgnoreStart
-					if ($this->logger)
-					{
-						$this->logger->error('Attempting to load an image of unsupported type JPG.');
-					}
+					$this->getLogger()->error('Attempting to load an image of unsupported type JPG.');
 
 					throw new \RuntimeException('Attempting to load an image of unsupported type JPG.');
 
@@ -615,10 +642,7 @@ class Image implements LoggerAwareInterface
 				if (empty(self::$formats[IMAGETYPE_PNG]))
 				{
 					// @codeCoverageIgnoreStart
-					if ($this->logger)
-					{
-						$this->logger->error('Attempting to load an image of unsupported type PNG.');
-					}
+					$this->getLogger()->error('Attempting to load an image of unsupported type PNG.');
 
 					throw new \RuntimeException('Attempting to load an image of unsupported type PNG.');
 
@@ -650,10 +674,7 @@ class Image implements LoggerAwareInterface
 				break;
 
 			default:
-				if ($this->logger)
-				{
-					$this->logger->error('Attempting to load an image of unsupported type ' . $properties->mime);
-				}
+				$this->getLogger()->error('Attempting to load an image of unsupported type ' . $properties->mime);
 
 				throw new \InvalidArgumentException('Attempting to load an image of unsupported type ' . $properties->mime);
 		}
@@ -904,14 +925,11 @@ class Image implements LoggerAwareInterface
 		$type = strtolower(preg_replace('#[^A-Z0-9_]#i', '', $type));
 
 		// Verify that the filter type exists.
-		$className = '\\Joomla\\Image\\Filter\\' . ucfirst($type);
+		$className = 'Joomla\\Image\\Filter\\' . ucfirst($type);
 
 		if (!class_exists($className))
 		{
-			if ($this->logger)
-			{
-				$this->logger->error('The ' . ucfirst($type) . ' image filter is not available.');
-			}
+			$this->getLogger()->error('The ' . ucfirst($type) . ' image filter is not available.');
 
 			throw new \RuntimeException('The ' . ucfirst($type) . ' image filter is not available.');
 		}
@@ -923,10 +941,7 @@ class Image implements LoggerAwareInterface
 		if (!($instance instanceof ImageFilter))
 		{
 			// @codeCoverageIgnoreStart
-			if ($this->logger)
-			{
-				$this->logger->error('The ' . ucfirst($type) . ' image filter is not valid.');
-			}
+			$this->getLogger()->error('The ' . ucfirst($type) . ' image filter is not valid.');
 
 			throw new \RuntimeException('The ' . ucfirst($type) . ' image filter is not valid.');
 

--- a/src/Joomla/Image/ImageFilter.php
+++ b/src/Joomla/Image/ImageFilter.php
@@ -74,24 +74,12 @@ abstract class ImageFilter implements LoggerAwareInterface
 	public function getLogger()
 	{
 		// If a logger hasn't been set, use NullLogger
-		if (! $this->hasLogger())
+		if (! ($this->logger instanceof LoggerInterface))
 		{
 			$this->logger = new NullLogger;
 		}
 
 		return $this->logger;
-	}
-
-	/**
-	 * Checks if a logger is available.
-	 *
-	 * @return  boolean
-	 *
-	 * @since   1.0
-	 */
-	public function hasLogger()
-	{
-		return ($this->logger instanceof LoggerInterface);
 	}
 
 	/**

--- a/src/Joomla/Image/ImageFilter.php
+++ b/src/Joomla/Image/ImageFilter.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\Image;
 
+use Psr\Log\NullLogger;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerAwareInterface;
 
@@ -45,10 +46,7 @@ abstract class ImageFilter implements LoggerAwareInterface
 		if (!function_exists('imagefilter'))
 		{
 			// @codeCoverageIgnoreStart
-			if ($this->logger)
-			{
-				$this->logger->error('The imagefilter function for PHP is not available.');
-			}
+			$this->getLogger()->error('The imagefilter function for PHP is not available.');
 
 			throw new \RuntimeException('The imagefilter function for PHP is not available.');
 
@@ -58,10 +56,7 @@ abstract class ImageFilter implements LoggerAwareInterface
 		// Make sure the file handle is valid.
 		if (!is_resource($handle) || (get_resource_type($handle) != 'gd'))
 		{
-			if ($this->logger)
-			{
-				$this->logger->error('The image handle is invalid for the image filter.');
-			}
+			$this->getLogger()->error('The image handle is invalid for the image filter.');
 
 			throw new \InvalidArgumentException('The image handle is invalid for the image filter.');
 		}
@@ -70,17 +65,49 @@ abstract class ImageFilter implements LoggerAwareInterface
 	}
 
 	/**
+	 * Get the logger.
+	 *
+	 * @return  LoggerInterface
+	 *
+	 * @since   1.0
+	 */
+	public function getLogger()
+	{
+		// If a logger hasn't been set, use NullLogger
+		if (! $this->hasLogger())
+		{
+			$this->logger = new NullLogger;
+		}
+
+		return $this->logger;
+	}
+
+	/**
+	 * Checks if a logger is available.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   1.0
+	 */
+	public function hasLogger()
+	{
+		return ($this->logger instanceof LoggerInterface);
+	}
+
+	/**
 	 * Sets a logger instance on the object
 	 *
 	 * @param   LoggerInterface  $logger  A PSR-3 compliant logger.
 	 *
-	 * @return  void
+	 * @return  Image  This object for message chaining.
 	 *
 	 * @since   1.0
 	 */
 	public function setLogger(LoggerInterface $logger)
 	{
 		$this->logger = $logger;
+
+		return $this;
 	}
 
 	/**

--- a/src/Joomla/Image/Tests/ImageFilterTest.php
+++ b/src/Joomla/Image/Tests/ImageFilterTest.php
@@ -5,7 +5,7 @@
  */
 
 use Joomla\Image\Filter\Brightness as FilterBrightness;
-
+use Joomla\Image\Filter\Inspector as FilterInspector;
 use Joomla\Test\TestHelper;
 
 /**
@@ -15,6 +15,11 @@ use Joomla\Test\TestHelper;
  */
 class ImageFilterTest extends PHPUnit_Framework_TestCase
 {
+	/**
+	 * @var  FilterInspector  The object to test.
+	 */
+	protected $instance;
+
 	/**
 	 * Setup for testing.
 	 *
@@ -31,19 +36,8 @@ class ImageFilterTest extends PHPUnit_Framework_TestCase
 		{
 			$this->markTestSkipped('No GD support so skipping Image tests.');
 		}
-	}
 
-	/**
-	 * Overrides the parent tearDown method.
-	 *
-	 * @return  void
-	 *
-	 * @see     PHPUnit_Framework_TestCase::tearDown()
-	 * @since   1.0
-	 */
-	protected function tearDown()
-	{
-		parent::tearDown();
+		$this->instance = new FilterInspector(imagecreate(10, 10));
 	}
 
 	/**
@@ -75,5 +69,63 @@ class ImageFilterTest extends PHPUnit_Framework_TestCase
 		$filter = new FilterBrightness($imageHandle);
 
 		$this->assertEquals(TestHelper::getValue($filter, 'handle'), $imageHandle);
+	}
+
+	/**
+	 * Tests the ImageFilter::getLogger for a NullLogger.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetNullLogger()
+	{
+		$logger = $this->instance->getLogger();
+
+		$this->assertInstanceOf(
+			'Psr\\Log\\NullLogger',
+			$logger,
+			'When a logger has not been set, an instance of NullLogger should be returned.'
+		);
+	}
+
+	/**
+	 * Tests the ImageFilter::hasLogger method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testHasLogger()
+	{
+		$this->assertFalse($this->instance->hasLogger());
+
+		$mockLogger = $this->getMock('Psr\\Log\\AbstractLogger', array('log'), array(), '', false);
+		$this->instance->setLogger($mockLogger);
+
+		$this->assertTrue($this->instance->hasLogger());
+	}
+
+	/**
+	 * Tests the ImageFilter::setLogger and Image::getLogger.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSetLogger()
+	{
+		$mockLogger = $this->getMock('Psr\\Log\\AbstractLogger', array('log'), array(), '', false);
+
+		$this->assertSame(
+			$this->instance,
+			$this->instance->setLogger($mockLogger),
+			'The current instance of the application is returned when using setLogger. This is to support chaining.'
+		);
+		$this->assertSame(
+			$mockLogger,
+			$this->instance->getLogger(),
+			'The getLogger method should return the same logger instance that was set via setLogger.'
+		);
 	}
 }

--- a/src/Joomla/Image/Tests/ImageFilterTest.php
+++ b/src/Joomla/Image/Tests/ImageFilterTest.php
@@ -90,23 +90,6 @@ class ImageFilterTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests the ImageFilter::hasLogger method.
-	 *
-	 * @return  void
-	 *
-	 * @since   1.0
-	 */
-	public function testHasLogger()
-	{
-		$this->assertFalse($this->instance->hasLogger());
-
-		$mockLogger = $this->getMock('Psr\\Log\\AbstractLogger', array('log'), array(), '', false);
-		$this->instance->setLogger($mockLogger);
-
-		$this->assertTrue($this->instance->hasLogger());
-	}
-
-	/**
 	 * Tests the ImageFilter::setLogger and Image::getLogger.
 	 *
 	 * @return  void

--- a/src/Joomla/Image/Tests/ImageTest.php
+++ b/src/Joomla/Image/Tests/ImageTest.php
@@ -17,6 +17,13 @@ use Joomla\Image\Image;
 class ImageTest extends PHPUnit_Framework_TestCase
 {
 	/**
+	 * @var    Image  The testing instance.
+	 *
+	 * @since  1.0
+	 */
+	protected $instance;
+
+	/**
 	 * Setup for testing.
 	 *
 	 * @return  void
@@ -33,6 +40,8 @@ class ImageTest extends PHPUnit_Framework_TestCase
 			$this->markTestSkipped('No GD support so skipping Image tests.');
 		}
 
+		$this->instance = new Image;
+
 		$this->testFile = __DIR__ . '/stubs/koala.jpg';
 
 		$this->testFileGif = __DIR__ . '/stubs/koala.gif';
@@ -40,19 +49,6 @@ class ImageTest extends PHPUnit_Framework_TestCase
 		$this->testFilePng = __DIR__ . '/stubs/koala.png';
 
 		$this->testFileBmp = __DIR__ . '/stubs/koala.bmp';
-	}
-
-	/**
-	 * Overrides the parent tearDown method.
-	 *
-	 * @return  void
-	 *
-	 * @see     PHPUnit_Framework_TestCase::tearDown()
-	 * @since   1.0
-	 */
-	protected function tearDown()
-	{
-		parent::tearDown();
 	}
 
 	/**
@@ -979,5 +975,63 @@ class ImageTest extends PHPUnit_Framework_TestCase
 
 		// Destroying the image should return boolean true
 		$this->assertTrue($image->destroy());
+	}
+
+	/**
+	 * Tests the Image::getLogger for a NullLogger.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetNullLogger()
+	{
+		$logger = $this->instance->getLogger();
+
+		$this->assertInstanceOf(
+			'Psr\\Log\\NullLogger',
+			$logger,
+			'When a logger has not been set, an instance of NullLogger should be returned.'
+		);
+	}
+
+	/**
+	 * Tests the Image::hasLogger method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testHasLogger()
+	{
+		$this->assertFalse($this->instance->hasLogger());
+
+		$mockLogger = $this->getMock('Psr\\Log\\AbstractLogger', array('log'), array(), '', false);
+		$this->instance->setLogger($mockLogger);
+
+		$this->assertTrue($this->instance->hasLogger());
+	}
+
+	/**
+	 * Tests the Image::setLogger and Image::getLogger.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSetLogger()
+	{
+		$mockLogger = $this->getMock('Psr\\Log\\AbstractLogger', array('log'), array(), '', false);
+
+		$this->assertSame(
+			$this->instance,
+			$this->instance->setLogger($mockLogger),
+			'The current instance of the application is returned when using setLogger. This is to support chaining.'
+		);
+		$this->assertSame(
+			$mockLogger,
+			$this->instance->getLogger(),
+			'The getLogger method should return the same logger instance that was set via setLogger.'
+		);
 	}
 }

--- a/src/Joomla/Image/Tests/ImageTest.php
+++ b/src/Joomla/Image/Tests/ImageTest.php
@@ -996,23 +996,6 @@ class ImageTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests the Image::hasLogger method.
-	 *
-	 * @return  void
-	 *
-	 * @since   1.0
-	 */
-	public function testHasLogger()
-	{
-		$this->assertFalse($this->instance->hasLogger());
-
-		$mockLogger = $this->getMock('Psr\\Log\\AbstractLogger', array('log'), array(), '', false);
-		$this->instance->setLogger($mockLogger);
-
-		$this->assertTrue($this->instance->hasLogger());
-	}
-
-	/**
 	 * Tests the Image::setLogger and Image::getLogger.
 	 *
 	 * @return  void


### PR DESCRIPTION
PSR-3 (the logging interface) comes prepackaged with a `NullLogger` that allows us to reduce a lot of our checking code around the usage of a logger. Currently (although inconsistent) most places use something like this:

``` php
if ($this->hasLogger())
{
    $this->getLogger()->log('some message');
}
```

Using a `NullLogger`, we can reduce this to a single line:

``` php
$this->getLogger()->log('some message');
```

The `getLogger` method has been modified to return a `NullLogger` if `$this->logger` is not set or if it's not an `instanceof Psr\Log\LoggerInterface`.

Being that this is an RFC, I wanted to get some feedback on it before implementing it everywhere else we use a logger. Please :+1: or :-1: your opinion on the matter and whether or not you think we should use this approach.
