### PR TITLE
detectRequestUri uses improved isSSLConnection

### DIFF
--- a/src/Joomla/Application/AbstractWebApplication.php
+++ b/src/Joomla/Application/AbstractWebApplication.php
@@ -571,7 +571,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	protected function detectRequestUri()
 	{
 		// First we need to detect the URI scheme.
-		if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+		if ($this->isSSLConnection())
 		{
 			$scheme = 'https://';
 		}
@@ -638,7 +638,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 */
 	public function isSSLConnection()
 	{
-		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION'));
+		return (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) != 'off');
 	}
 
 	/**


### PR DESCRIPTION
- `detectRequestUri` uses `isSSLConnection` instead of own - duplicated code.
- `isSSLConnection` has been improved:
  - concatenated `isset` and `!empty` checks into one (see: php.net: [empty](http://us1.php.net/empty), [$_SERVER['HTTPS']](http://www.php.net/manual/en/reserved.variables.server.php))
  - no more checks for `getenv('SSL_PROTOCOL_VERSION')`, this variable has been renamed to [`SSL_VERSION`](http://httpd.apache.org/docs/trunk/da/ssl/ssl_compat.html) anyway
  - for IIS the value is compared against lowercase off: `strtolower($_SERVER['HTTPS']) != 'off'`

See discussion on #213
