### PR TITLE
Remove unused $instance from Cli & Web Applicaiotn

### DIFF
--- a/src/Joomla/Application/AbstractCliApplication.php
+++ b/src/Joomla/Application/AbstractCliApplication.php
@@ -20,12 +20,6 @@ use Joomla\Application\Cli\CliOutput;
 abstract class AbstractCliApplication extends AbstractApplication
 {
 	/**
-	 * @var    AbstractCliApplication  The application instance.
-	 * @since  1.0
-	 */
-	private static $instance;
-
-	/**
 	 * @var    CliOutput  Output object
 	 * @since  1.0
 	 */

--- a/src/Joomla/Application/AbstractWebApplication.php
+++ b/src/Joomla/Application/AbstractWebApplication.php
@@ -62,14 +62,6 @@ abstract class AbstractWebApplication extends AbstractApplication
 	protected $response;
 
 	/**
-	 * The application instance.
-	 *
-	 * @var    AbstractWebApplication
-	 * @since  1.0
-	 */
-	private static $instance;
-
-	/**
 	 * The application session object.
 	 *
 	 * @var    Session


### PR DESCRIPTION
This is a light modification of #271 that removing the $instance from Application classes.
