### PR TITLE
Fix Yaml test in Windows

### DIFF
--- a/src/Joomla/Registry/Tests/format/FormatYamlTest.php
+++ b/src/Joomla/Registry/Tests/format/FormatYamlTest.php
@@ -79,7 +79,10 @@ array:
     nestedarray: { test1: value1 }
 ';
 
-		$this->assertEquals($this->fixture->objectToString($object), $yaml);
+		$this->assertEquals(
+			str_replace(array("\n", "\r"), '', trim($this->fixture->objectToString($object))),
+			str_replace(array("\n", "\r"), '', trim($yaml))
+		);
 	}
 
 	/**
@@ -114,7 +117,10 @@ array:
     nestedarray: { test1: value1 }
 ';
 
-		$this->assertEquals($this->fixture->objectToString($object), $yaml);
+		$this->assertEquals(
+			str_replace(array("\n", "\r"), '', trim($this->fixture->objectToString($object))),
+			str_replace(array("\n", "\r"), '', trim($yaml))
+		);
 	}
 
 	/**


### PR DESCRIPTION
`FormatYamlTest::testObjectToStringWithArray()` and `FormatYamlTest::testObjectToStringWithObject` methods return failure when testing in Windows.

It's caused by the EOL setting.

I repair this issue and tested in Windows with no failure.

![p2013-11-09-9](https://f.cloud.github.com/assets/1639206/1506887/e9445082-4953-11e3-9880-cf18460615f1.jpg)
