### PR TITLE
Add (string) before send text to ColorProcessor

### DIFF
--- a/src/Joomla/Application/Cli/Output/Stdout.php
+++ b/src/Joomla/Application/Cli/Output/Stdout.php
@@ -66,7 +66,7 @@ class Stdout extends CliOutput
 	 */
 	public function out($text = '', $nl = true)
 	{
-		fwrite(STDOUT, $this->processor->process($text) . ($nl ? "\n" : null));
+		fwrite(STDOUT, $this->processor->process((string) $text) . ($nl ? "\n" : null));
 
 		return $this;
 	}


### PR DESCRIPTION
To prevent user's mistake that sending a non-text variable to CliOutput.
