### PR TITLE
Fix that Registry asArray() can not handle objects recursively

### DIFF
--- a/src/Joomla/Registry/Registry.php
+++ b/src/Joomla/Registry/Registry.php
@@ -516,9 +516,14 @@ class Registry implements \JsonSerializable, \ArrayAccess
 	{
 		$array = array();
 
-		foreach (get_object_vars((object) $data) as $k => $v)
+		if (is_object($data))
 		{
-			if (is_object($v))
+			$data = get_object_vars($data);
+		}
+
+		foreach ($data as $k => $v)
+		{
+			if (is_object($v) || is_array($v))
 			{
 				$array[$k] = $this->asArray($v);
 			}


### PR DESCRIPTION
When we call `Registry::toArray()` or `Registry::asArray()`, some objects in this nested array will not be convert to array.

This will make YamlDumper ignore some data in Registry.

I fixed this issue, `asArray()` will return all truly nested array.
