### PR TITLE
Remove PHP 5.3.6 check from MySQL database driver

### DIFF
--- a/src/Joomla/Database/Mysql/MysqlDriver.php
+++ b/src/Joomla/Database/Mysql/MysqlDriver.php
@@ -12,7 +12,7 @@ use Joomla\Database\Pdo\PdoDriver;
 use Psr\Log;
 
 /**
- * MySQL database driver
+ * MySQL database driver supporting PDO based connections
  *
  * @see    http://dev.mysql.com/doc/
  * @since  1.0
@@ -48,7 +48,9 @@ class MysqlDriver extends PdoDriver
 	protected $nullDate = '0000-00-00 00:00:00';
 
 	/**
-	 * @var    string  The minimum supported database version.
+	 * The minimum supported database version.
+	 *
+	 * @var    string
 	 * @since  1.0
 	 */
 	protected static $dbMinimum = '5.0.4';
@@ -63,14 +65,8 @@ class MysqlDriver extends PdoDriver
 	public function __construct($options)
 	{
 		// Get some basic values from the options.
-		$options['driver']	 = 'mysql';
-		$options['charset'] = (isset($options['charset'])) ? $options['charset']   : 'utf8';
-
-		// Setting the charset in the DSN doesn't work until PHP 5.3.6
-		if (version_compare(PHP_VERSION, '5.3.6', '<'))
-		{
-			$options['driverOptions'] = array(\PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8');
-		}
+		$options['driver']	= 'mysql';
+		$options['charset'] = (isset($options['charset'])) ? $options['charset'] : 'utf8';
 
 		$this->charset = $options['charset'];
 

--- a/src/Joomla/Database/Pdo/PdoDriver.php
+++ b/src/Joomla/Database/Pdo/PdoDriver.php
@@ -209,10 +209,10 @@ abstract class PdoDriver extends DatabaseDriver
 			case 'mysql':
 				$this->options['port'] = (isset($this->options['port'])) ? $this->options['port'] : 3306;
 
-				$format = 'mysql:host=#HOST#;port=#PORT#;dbname=#DBNAME#';
+				$format = 'mysql:host=#HOST#;port=#PORT#;dbname=#DBNAME#;charset=#CHARSET#';
 
-				$replace = array('#HOST#', '#PORT#', '#DBNAME#');
-				$with = array($this->options['host'], $this->options['port'], $this->options['database']);
+				$replace = array('#HOST#', '#PORT#', '#DBNAME#', '#CHARSET#');
+				$with = array($this->options['host'], $this->options['port'], $this->options['database'], $this->options['charset']);
 
 				break;
 


### PR DESCRIPTION
Currently `MysqlDriver` has a check in its constructor dealing with a change in PHP 5.3.6.  As our minimum is 5.3.10, we don't need this check.

Note the changes in the doc blocks are just me working on cleaning things up a bit more after getting `phpdoc` running and reviewing things based on that.
