### PR TITLE
Deprecate PostgresqlDriver::test()

### DIFF
--- a/src/Joomla/Database/Postgresql/PostgresqlDriver.php
+++ b/src/Joomla/Database/Postgresql/PostgresqlDriver.php
@@ -209,11 +209,14 @@ class PostgresqlDriver extends DatabaseDriver
 	/**
 	 * Test to see if the PostgreSQL connector is available
 	 *
-	 * @return boolean  True on success, false otherwise.
+	 * @return  boolean  True on success, false otherwise.
+	 *
+	 * @since   1.0
+	 * @deprecated  2.0  Use isSupported() instead
 	 */
 	public static function test()
 	{
-		return (function_exists('pg_connect'));
+		return static::isSupported();
 	}
 
 	/**

--- a/src/Joomla/Database/Tests/DriverPostgresqlTest.php
+++ b/src/Joomla/Database/Tests/DriverPostgresqlTest.php
@@ -879,6 +879,7 @@ class DriverPostgresqlTest extends DatabasePostgresqlCase
 	 * @return  void
 	 *
 	 * @since   1.0
+	 * @deprecated  2.0
 	 */
 	public function testTest()
 	{


### PR DESCRIPTION
This really should have been removed at Platform 12.1 with the original refactoring or during the last 11 months of work, but it is what it is now.
