### PR TITLE
Cleanup based on phpdoc output and file review

### DIFF
--- a/src/Joomla/Application/AbstractApplication.php
+++ b/src/Joomla/Application/AbstractApplication.php
@@ -143,7 +143,8 @@ abstract class AbstractApplication implements LoggerAwareInterface
 	/**
 	 * Custom initialisation method.
 	 *
-	 * Called at the end of the Base::__construct method. This is for developers to inject initialisation code for their application classes.
+	 * Called at the end of the AbstractApplication::__construct method.
+	 * This is for developers to inject initialisation code for their application classes.
 	 *
 	 * @return  void
 	 *

--- a/src/Joomla/Archive/Bzip2.php
+++ b/src/Joomla/Archive/Bzip2.php
@@ -12,7 +12,7 @@ use Joomla\Filesystem\File;
 use Joomla\Filesystem\Stream;
 
 /**
- * Bzip2 format adapter for the JArchive class
+ * Bzip2 format adapter for the Archive package
  *
  * @since  1.0
  */

--- a/src/Joomla/Archive/Gzip.php
+++ b/src/Joomla/Archive/Gzip.php
@@ -12,7 +12,7 @@ use Joomla\Filesystem\File;
 use Joomla\Filesystem\Stream;
 
 /**
- * Gzip format adapter for the JArchive class
+ * Gzip format adapter for the Archive package
  *
  * This class is inspired from and draws heavily in code and concept from the Compress package of
  * The Horde Project <http://www.horde.org>

--- a/src/Joomla/Crypt/Cipher/3DES.php
+++ b/src/Joomla/Crypt/Cipher/3DES.php
@@ -9,7 +9,7 @@
 namespace Joomla\Crypt;
 
 /**
- * JCrypt cipher for Triple DES encryption, decryption and key generation.
+ * Cipher class for Triple DES encryption, decryption and key generation.
  *
  * @since  1.0
  */

--- a/src/Joomla/Crypt/Cipher/Blowfish.php
+++ b/src/Joomla/Crypt/Cipher/Blowfish.php
@@ -9,7 +9,7 @@
 namespace Joomla\Crypt;
 
 /**
- * JCrypt cipher for Blowfish encryption, decryption and key generation.
+ * Cipher class for Blowfish encryption, decryption and key generation.
  *
  * @since  1.0
  */

--- a/src/Joomla/Crypt/Cipher/Mcrypt.php
+++ b/src/Joomla/Crypt/Cipher/Mcrypt.php
@@ -9,7 +9,7 @@
 namespace Joomla\Crypt;
 
 /**
- * JCrypt cipher for mcrypt algorithm encryption, decryption and key generation.
+ * Cipher class for mcrypt algorithm encryption, decryption and key generation.
  *
  * @since  1.0
  */

--- a/src/Joomla/Crypt/Cipher/Rijndael256.php
+++ b/src/Joomla/Crypt/Cipher/Rijndael256.php
@@ -9,7 +9,7 @@
 namespace Joomla\Crypt;
 
 /**
- * JCrypt cipher for Rijndael 256 encryption, decryption and key generation.
+ * Cipher class for Rijndael 256 encryption, decryption and key generation.
  *
  * @since  1.0
  */

--- a/src/Joomla/Crypt/Cipher/Simple.php
+++ b/src/Joomla/Crypt/Cipher/Simple.php
@@ -9,7 +9,7 @@
 namespace Joomla\Crypt;
 
 /**
- * JCrypt cipher for Simple encryption, decryption and key generation.
+ * Cipher class for Simple encryption, decryption and key generation.
  *
  * @since  1.0
  */

--- a/src/Joomla/Crypt/CipherInterface.php
+++ b/src/Joomla/Crypt/CipherInterface.php
@@ -9,7 +9,7 @@
 namespace Joomla\Crypt;
 
 /**
- * JCrypt cipher interface.
+ * Joomla Framework Cipher interface.
  *
  * @since  1.0
  */

--- a/src/Joomla/Crypt/Crypt.php
+++ b/src/Joomla/Crypt/Crypt.php
@@ -92,7 +92,7 @@ class Crypt
 	 *
 	 * @param   Key  $key  The key object to set.
 	 *
-	 * @return  Key
+	 * @return  Crypt  Instance of $this to allow chaining.
 	 *
 	 * @since   1.0
 	 */
@@ -110,7 +110,7 @@ class Crypt
 	 *
 	 * @return  string  Random binary data
 	 *
-	 * @since  1.0
+	 * @since   1.0
 	 */
 	public static function genRandomBytes($length = 16)
 	{

--- a/src/Joomla/Crypt/Password/Simple.php
+++ b/src/Joomla/Crypt/Password/Simple.php
@@ -54,19 +54,19 @@ class Simple implements PasswordInterface
 			case PasswordInterface::BLOWFISH:
 				$salt = '$2y$' . str_pad($this->cost, 2, '0', STR_PAD_LEFT) . '$' . $this->getSalt(22);
 
-			return crypt($password, $salt);
+				return crypt($password, $salt);
 
 			case PasswordInterface::MD5:
 				$salt = $this->getSalt(12);
 
 				$salt = '$1$' . $salt;
 
-			return crypt($password, $salt);
+				return crypt($password, $salt);
 
 			case PasswordInterface::JOOMLA:
 				$salt = $this->getSalt(32);
 
-			return md5($password . $salt) . ':' . $salt;
+				return md5($password . $salt) . ':' . $salt;
 
 			default:
 				throw new \InvalidArgumentException(sprintf('Hash type %s is not supported', $type));
@@ -170,7 +170,7 @@ class Simple implements PasswordInterface
 	/**
 	 * Gets the default type
 	 *
-	 * @return   string  $type  The default type
+	 * @return  string  $type  The default type
 	 *
 	 * @since   1.0
 	 */

--- a/src/Joomla/DI/Container.php
+++ b/src/Joomla/DI/Container.php
@@ -21,7 +21,6 @@ class Container
 	 * Holds the key aliases.
 	 *
 	 * @var    array  $aliases
-	 *
 	 * @since  1.0
 	 */
 	protected $aliases = array();
@@ -30,7 +29,6 @@ class Container
 	 * Holds the shared instances.
 	 *
 	 * @var    array  $instances
-	 *
 	 * @since  1.0
 	 */
 	protected $instances = array();
@@ -40,7 +38,6 @@ class Container
 	 * the item is meant to be a shared resource.
 	 *
 	 * @var    array  $dataStore
-	 *
 	 * @since  1.0
 	 */
 	protected $dataStore = array();
@@ -49,7 +46,6 @@ class Container
 	 * Parent for hierarchical containers.
 	 *
 	 * @var    Container
-	 *
 	 * @since  1.0
 	 */
 	protected $parent;
@@ -59,7 +55,7 @@ class Container
 	 *
 	 * @param   Container  $parent  Parent for hierarchical containers.
 	 *
-	 * @since  1.0
+	 * @since   1.0
 	 */
 	public function __construct(Container $parent = null)
 	{
@@ -72,7 +68,9 @@ class Container
 	 * @param   string  $alias  The alias name
 	 * @param   string  $key    The key to alias
 	 *
-	 * @return  Container
+	 * @return  Container  This object for chaining.
+	 *
+	 * @since   1.0
 	 */
 	public function alias($alias, $key)
 	{
@@ -162,9 +160,9 @@ class Container
 	 * Create a child Container with a new property scope that
 	 * that has the ability to access the parent scope when resolving.
 	 *
-	 * @return Container
+	 * @return  Container  This object for chaining.
 	 *
-	 * @since  1.0
+	 * @since   1.0
 	 */
 	public function createChild()
 	{
@@ -263,9 +261,9 @@ class Container
 	 * @param   boolean  $shared     True to create and store a shared instance.
 	 * @param   boolean  $protected  True to protect this item from being overwritten. Useful for services.
 	 *
-	 * @return  \Joomla\DI\Container  This instance to support chaining.
+	 * @return  Container  This object for chaining.
 	 *
-	 * @throws  \OutOfBoundsException      Thrown if the provided key is already set and is protected.
+	 * @throws  \OutOfBoundsException  Thrown if the provided key is already set and is protected.
 	 *
 	 * @since   1.0
 	 */
@@ -300,7 +298,7 @@ class Container
 	 * @param   callable  $callback  Callable function to run when requesting the specified $key.
 	 * @param   bool      $shared    True to create and store a shared instance.
 	 *
-	 * @return  \Joomla\DI\Container  This instance to support chaining.
+	 * @return  Container  This object for chaining.
 	 *
 	 * @since   1.0
 	 */
@@ -316,7 +314,7 @@ class Container
 	 * @param   callable  $callback   Callable function to run when requesting the specified $key.
 	 * @param   bool      $protected  True to create and store a shared instance.
 	 *
-	 * @return  \Joomla\DI\Container  This instance to support chaining.
+	 * @return  Container  This object for chaining.
 	 *
 	 * @since   1.0
 	 */
@@ -364,6 +362,8 @@ class Container
 	 * @param   string  $key  The key for which to get the stored item.
 	 *
 	 * @return  mixed
+	 *
+	 * @since   1.0
 	 */
 	protected function getRaw($key)
 	{

--- a/src/Joomla/DI/Exception/DependencyResolutionException.php
+++ b/src/Joomla/DI/Exception/DependencyResolutionException.php
@@ -9,11 +9,10 @@
 namespace Joomla\DI\Exception;
 
 /**
- * Defines the interface for a Container Aware class.
+ * Exception class for handling errors in resolving a dependency
  *
  * @since  1.0
  */
 class DependencyResolutionException extends \Exception
 {
-	// Noop
 }

--- a/src/Joomla/Data/DataObject.php
+++ b/src/Joomla/Data/DataObject.php
@@ -11,7 +11,7 @@ namespace Joomla\Data;
 use Joomla\Registry\Registry;
 
 /**
- * Data\DataObject is a class that is used to store data but allowing you to access the data
+ * DataObject is a class that is used to store data but allowing you to access the data
  * by mimicking the way PHP handles class properties.
  *
  * @since  1.0
@@ -169,7 +169,7 @@ class DataObject implements DumpableInterface, \IteratorAggregate, \JsonSerializ
 	 *                                      form. A depth of 1 will recurse into the first level of properties only.
 	 * @param   \SplObjectStorage  $dumped  An array of already serialized objects that is used to avoid infinite loops.
 	 *
-	 * @return  object  The data properties as a simple PHP stdClass object.
+	 * @return  \stdClass  The data properties as a simple PHP stdClass object.
 	 *
 	 * @since   1.0
 	 */

--- a/src/Joomla/Data/DataSet.php
+++ b/src/Joomla/Data/DataSet.php
@@ -2,14 +2,14 @@
 /**
  * Part of the Joomla Framework Data Package
  *
- * @copyright  Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Data;
 
 /**
- * Data\Set is a collection class that allows the developer to operate on a set of Data\Object objects as if they were in a
+ * DataSet is a collection class that allows the developer to operate on a set of DataObject objects as if they were in a
  * typical PHP array.
  *
  * @since  1.0
@@ -233,9 +233,9 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
 	 *                                      form. A depth of 1 will recurse into the first level of properties only.
 	 * @param   \SplObjectStorage  $dumped  An array of already serialized objects that is used to avoid infinite loops.
 	 *
-	 * @return  array  An associative array of the date objects in the set, dumped as a simple PHP stdClass object.
+	 * @return  array  An associative array of the data objects in the set, dumped as a simple PHP stdClass object.
 	 *
-	 * @see     Joomla\Data\DataObject::dump()
+	 * @see     DataObject::dump()
 	 * @since   1.0
 	 */
 	public function dump($depth = 3, \SplObjectStorage $dumped = null)

--- a/src/Joomla/Database/DatabaseDriver.php
+++ b/src/Joomla/Database/DatabaseDriver.php
@@ -164,7 +164,7 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	protected $errorMsg;
 
 	/**
-	 * JDatabaseDriver instances container.
+	 * DatabaseDriver instances container.
 	 *
 	 * @var    array
 	 * @since  1.0
@@ -524,7 +524,7 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 
 	/**
 	 * Method that provides access to the underlying database connection. Useful for when you need to call a
-	 * proprietary method such as postgresql's lo_* methods.
+	 * proprietary method such as PostgreSQL's lo_* methods.
 	 *
 	 * @return  resource  The underlying database connection resource.
 	 *
@@ -815,7 +815,7 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	 * @param   object  &$object  A reference to an object whose public properties match the table fields.
 	 * @param   string  $key      The name of the primary key. If provided the object property is updated.
 	 *
-	 * @return  boolean    True on success.
+	 * @return  boolean  True on success.
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
@@ -848,8 +848,8 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 		// Create the base insert statement.
 		$query = $this->getQuery(true);
 		$query->insert($this->quoteName($table))
-				->columns($fields)
-				->values(implode(',', $values));
+			->columns($fields)
+			->values(implode(',', $values));
 
 		// Set the query and execute the insert.
 		$this->setQuery($query);
@@ -927,7 +927,7 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	 *
 	 * @param   string  $key     The name of a field on which to key the result array.
 	 * @param   string  $column  An optional column name. Instead of the whole row, only this column value will be in
-	 * the result array.
+	 *                           the result array.
 	 *
 	 * @return  mixed   The return value or null if the query failed.
 	 *
@@ -973,7 +973,7 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	 *
 	 * @param   integer  $offset  The row offset to use to build the result array.
 	 *
-	 * @return  mixed    The return value or null if the query failed.
+	 * @return  mixed  The return value or null if the query failed.
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
@@ -1007,7 +1007,7 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	 *
 	 * @param   string  $class  The class name to use for the returned row object.
 	 *
-	 * @return  mixed   The return value or null if the query failed.
+	 * @return  mixed  The return value or null if the query failed.
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
@@ -1048,7 +1048,7 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	 * @param   string  $key    The name of a field on which to key the result array.
 	 * @param   string  $class  The class name to use for the returned row objects.
 	 *
-	 * @return  mixed   The return value or null if the query failed.
+	 * @return  mixed  The return value or null if the query failed.
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException

--- a/src/Joomla/Database/DatabaseExporter.php
+++ b/src/Joomla/Database/DatabaseExporter.php
@@ -16,7 +16,7 @@ namespace Joomla\Database;
 abstract class DatabaseExporter
 {
 	/**
-	 * The type of output format (xml).
+	 * The type of output format.
 	 *
 	 * @var    string
 	 * @since  1.0
@@ -170,7 +170,7 @@ abstract class DatabaseExporter
 		}
 		else
 		{
-			throw new \Exception('JPLATFORM_ERROR_INPUT_REQUIRES_STRING_OR_ARRAY');
+			throw new \Exception('The exporter requires either a single table name or array of table names');
 		}
 
 		return $this;

--- a/src/Joomla/Database/DatabaseImporter.php
+++ b/src/Joomla/Database/DatabaseImporter.php
@@ -16,7 +16,9 @@ namespace Joomla\Database;
 abstract class DatabaseImporter
 {
 	/**
-	 * @var    array  An array of cached data.
+	 * An array of cached data.
+	 *
+	 * @var    array
 	 * @since  1.0
 	 */
 	protected $cache = array();
@@ -38,7 +40,7 @@ abstract class DatabaseImporter
 	protected $from = array();
 
 	/**
-	 * The type of input format (XML).
+	 * The type of input format.
 	 *
 	 * @var    string
 	 * @since  1.0

--- a/src/Joomla/Database/DatabaseQuery.php
+++ b/src/Joomla/Database/DatabaseQuery.php
@@ -9,7 +9,7 @@
 namespace Joomla\Database;
 
 /**
- * Query Building Class.
+ * Joomla Framework Query Building Class.
  *
  * @since  1.0
  *
@@ -1298,14 +1298,13 @@ abstract class DatabaseQuery
 	}
 
 	/**
-	 * Allows a direct query to be provided to the database
-	 * driver's setQuery() method, but still allow queries
+	 * Allows a direct query to be provided to the database driver's setQuery() method, but still allow queries
 	 * to have bounded variables.
 	 *
 	 * Usage:
 	 * $query->setQuery('select * from #__users');
 	 *
-	 * @param   mixed  $sql  An SQL Query
+	 * @param   mixed  $sql  A SQL query string or DatabaseQuery object
 	 *
 	 * @return  DatabaseQuery  Returns this object to allow chaining.
 	 *
@@ -1398,8 +1397,7 @@ abstract class DatabaseQuery
 	}
 
 	/**
-	 * Method to provide deep copy support to nested objects and
-	 * arrays when cloning.
+	 * Method to provide deep copy support to nested objects and arrays when cloning.
 	 *
 	 * @return  void
 	 *

--- a/src/Joomla/Database/Mysql/MysqlDriver.php
+++ b/src/Joomla/Database/Mysql/MysqlDriver.php
@@ -14,7 +14,7 @@ use Psr\Log;
 /**
  * MySQL database driver
  *
- * @see    http://dev.mysql.com/doc/
+ * @see    http://php.net/manual/en/ref.pdo-mysql.php
  * @since  1.0
  */
 class MysqlDriver extends PdoDriver
@@ -231,8 +231,6 @@ class MysqlDriver extends PdoDriver
 
 		$result = array();
 
-		$query = $this->getQuery(true);
-
 		// Set the query to get the table fields statement.
 		$this->setQuery('SHOW FULL COLUMNS FROM ' . $this->quoteName($table));
 
@@ -271,8 +269,6 @@ class MysqlDriver extends PdoDriver
 	public function getTableKeys($table)
 	{
 		$this->connect();
-
-		$query = $this->getQuery(true);
 
 		// Get the details columns information.
 		$this->setQuery('SHOW KEYS FROM ' . $this->quoteName($table));
@@ -331,7 +327,7 @@ class MysqlDriver extends PdoDriver
 
 		$this->setQuery('LOCK TABLES ' . $this->quoteName($table) . ' WRITE');
 
-		$this->setQuery($query)->exec();
+		$this->setQuery($query)->execute();
 
 		return $this;
 	}
@@ -351,8 +347,6 @@ class MysqlDriver extends PdoDriver
 	 */
 	public function renameTable($oldTable, $newTable, $backup = null, $prefix = null)
 	{
-		$query = $this->getQuery(true);
-
 		$this->setQuery('RENAME TABLE ' . $this->quoteName($oldTable) . ' TO ' . $this->quoteName($newTable));
 
 		$this->execute();
@@ -485,15 +479,17 @@ class MysqlDriver extends PdoDriver
 
 		if (!$asSavepoint || !$this->transactionDepth)
 		{
-			return parent::transactionStart($asSavepoint);
+			parent::transactionStart($asSavepoint);
 		}
-
-		$savepoint = 'SP_' . $this->transactionDepth;
-		$this->setQuery('SAVEPOINT ' . $this->quoteName($savepoint));
-
-		if ($this->execute())
+		else
 		{
-			$this->transactionDepth++;
+			$savepoint = 'SP_' . $this->transactionDepth;
+			$this->setQuery('SAVEPOINT ' . $this->quoteName($savepoint));
+
+			if ($this->execute())
+			{
+				$this->transactionDepth++;
+			}
 		}
 	}
 }

--- a/src/Joomla/Database/Mysql/MysqlExporter.php
+++ b/src/Joomla/Database/Mysql/MysqlExporter.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Mysql;
 use Joomla\Database\DatabaseExporter;
 
 /**
- * MySQL export driver.
+ * MySQL Database Exporter.
  *
  * @since  1.0
  */

--- a/src/Joomla/Database/Mysql/MysqlImporter.php
+++ b/src/Joomla/Database/Mysql/MysqlImporter.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Mysql;
 use Joomla\Database\DatabaseImporter;
 
 /**
- * MySQL import driver.
+ * MySQL Database Importer.
  *
  * @since  1.0
  */
@@ -423,13 +423,13 @@ class MysqlImporter extends DatabaseImporter
 		// Check if the db connector has been set.
 		if (!($this->db instanceof MysqlDriver))
 		{
-			throw new \Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
+			throw new \Exception('Database connection wrong type.');
 		}
 
 		// Check if the tables have been specified.
 		if (empty($this->from))
 		{
-			throw new \Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
+			throw new \Exception('ERROR: No Tables Specified');
 		}
 
 		return $this;

--- a/src/Joomla/Database/Mysql/MysqlIterator.php
+++ b/src/Joomla/Database/Mysql/MysqlIterator.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Mysql;
 use Joomla\Database\Pdo\PdoIterator;
 
 /**
- * MySQL database iterator.
+ * MySQL Database Iterator
  *
  * @see    http://dev.mysql.com/doc/
  * @since  1.0

--- a/src/Joomla/Database/Mysql/MysqlQuery.php
+++ b/src/Joomla/Database/Mysql/MysqlQuery.php
@@ -12,20 +12,24 @@ use Joomla\Database\DatabaseQuery;
 use Joomla\Database\Query\LimitableInterface;
 
 /**
- * Query Building Class.
+ * MySQL Query Building Class.
  *
  * @since  1.0
  */
 class MysqlQuery extends DatabaseQuery implements LimitableInterface
 {
 	/**
-	 * @var    integer  The offset for the result set.
+	 * The offset for the result set.
+	 *
+	 * @var    integer
 	 * @since  1.0
 	 */
 	protected $offset;
 
 	/**
-	 * @var    integer  The limit for the result set.
+	 * The limit for the result set.
+	 *
+	 * @var    integer
 	 * @since  1.0
 	 */
 	protected $limit;

--- a/src/Joomla/Database/Mysqli/MysqliDriver.php
+++ b/src/Joomla/Database/Mysqli/MysqliDriver.php
@@ -12,7 +12,7 @@ use Joomla\Database\DatabaseDriver;
 use Psr\Log;
 
 /**
- * MySQLi database driver
+ * MySQLi Database Driver
  *
  * @see    http://php.net/manual/en/book.mysqli.php
  * @since  1.0
@@ -48,7 +48,9 @@ class MysqliDriver extends DatabaseDriver
 	protected $nullDate = '0000-00-00 00:00:00';
 
 	/**
-	 * @var    string  The minimum supported database version.
+	 * The minimum supported database version.
+	 *
+	 * @var    string
 	 * @since  1.0
 	 */
 	protected static $dbMinimum = '5.0.4';
@@ -158,9 +160,9 @@ class MysqliDriver extends DatabaseDriver
 		}
 
 		// Make sure the MySQLi extension for PHP is installed and enabled.
-		if (!function_exists('mysqli_connect'))
+		if (!static::isSupported())
 		{
-			throw new \RuntimeException('The MySQL adapter mysqli is not available');
+			throw new \RuntimeException('The MySQLi extension is not available');
 		}
 
 		$this->connection = @mysqli_connect(
@@ -229,7 +231,7 @@ class MysqliDriver extends DatabaseDriver
 	}
 
 	/**
-	 * Test to see if the MySQL connector is available.
+	 * Test to see if the MySQLi connector is available.
 	 *
 	 * @return  boolean  True on success, false otherwise.
 	 *
@@ -272,9 +274,7 @@ class MysqliDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		$query = $this->getQuery(true);
-
-		$this->setQuery('DROP TABLE ' . ($ifExists ? 'IF EXISTS ' : '') . $query->quoteName($tableName));
+		$this->setQuery('DROP TABLE ' . ($ifExists ? 'IF EXISTS ' : '') . $this->quoteName($tableName));
 
 		$this->execute();
 
@@ -359,7 +359,7 @@ class MysqliDriver extends DatabaseDriver
 		foreach ($tables as $table)
 		{
 			// Set the query to get the table CREATE statement.
-			$this->setQuery('SHOW CREATE table ' . $this->quoteName($this->escape($table)));
+			$this->setQuery('SHOW CREATE TABLE ' . $this->quoteName($this->escape($table)));
 			$row = $this->loadRow();
 
 			// Populate the result array based on the create statements.

--- a/src/Joomla/Database/Mysqli/MysqliExporter.php
+++ b/src/Joomla/Database/Mysqli/MysqliExporter.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Mysqli;
 use Joomla\Database\DatabaseExporter;
 
 /**
- * MySQLi export driver.
+ * MySQLi Database Exporter.
  *
  * @since  1.0
  */
@@ -98,13 +98,13 @@ class MysqliExporter extends DatabaseExporter
 		// Check if the db connector has been set.
 		if (!($this->db instanceof MysqliDriver))
 		{
-			throw new \Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
+			throw new \Exception('Database connection wrong type.');
 		}
 
 		// Check if the tables have been specified.
 		if (empty($this->from))
 		{
-			throw new \Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
+			throw new \Exception('ERROR: No Tables Specified');
 		}
 
 		return $this;

--- a/src/Joomla/Database/Mysqli/MysqliImporter.php
+++ b/src/Joomla/Database/Mysqli/MysqliImporter.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Mysqli;
 use Joomla\Database\DatabaseImporter;
 
 /**
- * MySQLi import driver.
+ * MySQLi Database Importer.
  *
  * @since  1.0
  */
@@ -30,13 +30,13 @@ class MysqliImporter extends DatabaseImporter
 		// Check if the db connector has been set.
 		if (!($this->db instanceof MysqliDriver))
 		{
-			throw new \Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
+			throw new \Exception('Database connection wrong type.');
 		}
 
 		// Check if the tables have been specified.
 		if (empty($this->from))
 		{
-			throw new \Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
+			throw new \Exception('ERROR: No Tables Specified');
 		}
 
 		return $this;

--- a/src/Joomla/Database/Mysqli/MysqliIterator.php
+++ b/src/Joomla/Database/Mysqli/MysqliIterator.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Mysqli;
 use Joomla\Database\DatabaseIterator;
 
 /**
- * MySQLi database iterator.
+ * MySQLi Database Iterator.
  *
  * @since  1.0
  */

--- a/src/Joomla/Database/Mysqli/MysqliQuery.php
+++ b/src/Joomla/Database/Mysqli/MysqliQuery.php
@@ -12,20 +12,24 @@ use Joomla\Database\DatabaseQuery;
 use Joomla\Database\Query\LimitableInterface;
 
 /**
- * Query Building Class.
+ * MySQLi Query Building Class.
  *
  * @since  1.0
  */
 class MysqliQuery extends DatabaseQuery implements LimitableInterface
 {
 	/**
-	 * @var    integer  The offset for the result set.
+	 * The offset for the result set.
+	 *
+	 * @var    integer
 	 * @since  1.0
 	 */
 	protected $offset;
 
 	/**
-	 * @var    integer  The limit for the result set.
+	 * The limit for the result set.
+	 *
+	 * @var    integer
 	 * @since  1.0
 	 */
 	protected $limit;

--- a/src/Joomla/Database/Oracle/OracleDriver.php
+++ b/src/Joomla/Database/Oracle/OracleDriver.php
@@ -11,9 +11,9 @@ namespace Joomla\Database\Oracle;
 use Joomla\Database\Pdo\PdoDriver;
 
 /**
- * Oracle database driver
+ * Oracle Database Driver supporting PDO based connections
  *
- * @see    http://php.net/pdo
+ * @see    http://php.net/manual/en/ref.pdo-oci.php
  * @since  1.0
  */
 class OracleDriver extends PdoDriver
@@ -139,6 +139,7 @@ class OracleDriver extends PdoDriver
 	{
 		$this->connect();
 
+		/* @type  OracleQuery  $query */
 		$query = $this->getQuery(true);
 
 		$query->setQuery('DROP TABLE :tableName');
@@ -209,6 +210,8 @@ class OracleDriver extends PdoDriver
 		$this->connect();
 
 		$result = array();
+
+		/* @type  OracleQuery  $query */
 		$query = $this->getQuery(true);
 
 		$query->select('dbms_metadata.get_ddl(:type, :tableName)');
@@ -246,6 +249,8 @@ class OracleDriver extends PdoDriver
 		$this->connect();
 
 		$columns = array();
+
+		/* @type  OracleQuery  $query */
 		$query = $this->getQuery(true);
 
 		$fieldCasing = $this->getOption(\PDO::ATTR_CASE);
@@ -298,6 +303,7 @@ class OracleDriver extends PdoDriver
 	{
 		$this->connect();
 
+		/* @type  OracleQuery  $query */
 		$query = $this->getQuery(true);
 
 		$fieldCasing = $this->getOption(\PDO::ATTR_CASE);
@@ -334,6 +340,7 @@ class OracleDriver extends PdoDriver
 	{
 		$this->connect();
 
+		/* @type  OracleQuery  $query */
 		$query = $this->getQuery(true);
 
 		if ($includeDatabaseName)
@@ -380,7 +387,7 @@ class OracleDriver extends PdoDriver
 	{
 		$this->connect();
 
-		$this->setQuery("select value from nls_database_parameters where parameter = 'NLS_RDBMS_VERSION'");
+		$this->setQuery("SELECT value FROM nls_database_parameters WHERE parameter = 'NLS_RDBMS_VERSION'");
 
 		return $this->loadResult();
 	}
@@ -682,15 +689,17 @@ class OracleDriver extends PdoDriver
 
 		if (!$asSavepoint || !$this->transactionDepth)
 		{
-			return parent::transactionStart($asSavepoint);
+			parent::transactionStart($asSavepoint);
 		}
-
-		$savepoint = 'SP_' . $this->transactionDepth;
-		$this->setQuery('SAVEPOINT ' . $this->quoteName($savepoint));
-
-		if ($this->execute())
+		else
 		{
-			$this->transactionDepth++;
+			$savepoint = 'SP_' . $this->transactionDepth;
+			$this->setQuery('SAVEPOINT ' . $this->quoteName($savepoint));
+
+			if ($this->execute())
+			{
+				$this->transactionDepth++;
+			}
 		}
 	}
 }

--- a/src/Joomla/Database/Oracle/OracleIterator.php
+++ b/src/Joomla/Database/Oracle/OracleIterator.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Oracle;
 use Joomla\Database\Pdo\PdoIterator;
 
 /**
- * Oracle database iterator.
+ * Oracle Database Iterator.
  *
  * @since  1.0
  */

--- a/src/Joomla/Database/Oracle/OracleQuery.php
+++ b/src/Joomla/Database/Oracle/OracleQuery.php
@@ -20,19 +20,25 @@ use Joomla\Database\Query\LimitableInterface;
 class OracleQuery extends PdoQuery implements PreparableInterface, LimitableInterface
 {
 	/**
-	 * @var    integer  The limit for the result set.
+	 * The limit for the result set.
+	 *
+	 * @var    integer
 	 * @since  1.0
 	 */
 	protected $limit;
 
 	/**
-	 * @var    integer  The offset for the result set.
+	 * The offset for the result set.
+	 *
+	 * @var    integer
 	 * @since  1.0
 	 */
 	protected $offset;
 
 	/**
-	 * @var    mixed  Holds key / value pair of bound objects.
+	 * Holds key / value pair of bound objects.
+	 *
+	 * @var    mixed
 	 * @since  1.0
 	 */
 	protected $bounded = array();
@@ -130,9 +136,7 @@ class OracleQuery extends PdoQuery implements PreparableInterface, LimitableInte
 				break;
 		}
 
-		parent::clear($clause);
-
-		return $this;
+		return parent::clear($clause);
 	}
 
 	/**

--- a/src/Joomla/Database/Pdo/PdoDriver.php
+++ b/src/Joomla/Database/Pdo/PdoDriver.php
@@ -50,7 +50,9 @@ abstract class PdoDriver extends DatabaseDriver
 	protected $nullDate = '0000-00-00 00:00:00';
 
 	/**
-	 * @var    resource  The prepared statement.
+	 * The prepared statement.
+	 *
+	 * @var    resource
 	 * @since  1.0
 	 */
 	protected $prepared;
@@ -117,10 +119,6 @@ abstract class PdoDriver extends DatabaseDriver
 		{
 			throw new \RuntimeException('PDO Extension is not available.', 1);
 		}
-
-		// Initialize the connection string variable:
-		$replace = array();
-		$with = array();
 
 		// Find the correct PDO DSN Format to use:
 		switch ($this->options['driver'])

--- a/src/Joomla/Database/Pdo/PdoIterator.php
+++ b/src/Joomla/Database/Pdo/PdoIterator.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Pdo;
 use Joomla\Database\DatabaseIterator;
 
 /**
- * PDO database iterator.
+ * PDO Database Iterator.
  *
  * @since  1.0
  */

--- a/src/Joomla/Database/Postgresql/PostgresqlDriver.php
+++ b/src/Joomla/Database/Postgresql/PostgresqlDriver.php
@@ -12,7 +12,7 @@ use Psr\Log;
 use Joomla\Database\DatabaseDriver;
 
 /**
- * PostgreSQL database driver
+ * PostgreSQL Database Driver
  *
  * @since  1.0
  */
@@ -21,26 +21,35 @@ class PostgresqlDriver extends DatabaseDriver
 	/**
 	 * The database driver name
 	 *
-	 * @var string
+	 * @var    string
+	 * @since  1.0
 	 */
 	public $name = 'postgresql';
 
 	/**
-	 * Quote for named objects
+	 * The character(s) used to quote SQL statement names such as table names or field names,
+	 * etc. The child classes should define this as necessary.  If a single character string the
+	 * same character is used for both sides of the quoted name, else the first character will be
+	 * used for the opening quote and the second for the closing quote.
 	 *
-	 * @var string
+	 * @var    string
+	 * @since  1.0
 	 */
 	protected $nameQuote = '"';
 
 	/**
-	 *  The null/zero date string
+	 * The null or zero representation of a timestamp for the database driver.  This should be
+	 * defined in child classes to hold the appropriate value for the engine.
 	 *
-	 * @var string
+	 * @var    string
+	 * @since  1.0
 	 */
 	protected $nullDate = '1970-01-01 00:00:00';
 
 	/**
-	 * @var    string  The minimum supported database version.
+	 * The minimum supported database version.
+	 *
+	 * @var    string
 	 * @since  1.0
 	 */
 	protected static $dbMinimum = '8.3.18';
@@ -56,7 +65,7 @@ class PostgresqlDriver extends DatabaseDriver
 	/**
 	 * Query object returned by getQuery
 	 *
-	 * @var    \Joomla\Database\Postgresql\PostgresqlQuery
+	 * @var    PostgresqlQuery
 	 * @since  1.0
 	 */
 	protected $queryObject = null;
@@ -109,15 +118,15 @@ class PostgresqlDriver extends DatabaseDriver
 		}
 
 		// Make sure the postgresql extension for PHP is installed and enabled.
-		if (!function_exists('pg_connect'))
+		if (!static::isSupported())
 		{
 			throw new \RuntimeException('PHP extension pg_connect is not available.');
 		}
 
 		/*
-		* pg_connect() takes the port as separate argument. Therefore, we
-		* have to extract it from the host string (if povided).
-		*/
+		 * pg_connect() takes the port as separate argument. Therefore, we
+		 * have to extract it from the host string (if povided).
+		 */
 
 		// Check for empty port
 		if (!($this->options['port']))
@@ -310,7 +319,7 @@ class PostgresqlDriver extends DatabaseDriver
 	 * @param   boolean  $new    False to return the last query set, True to return a new Query object.
 	 * @param   boolean  $asObj  False to return last query as string, true to get Postgresql query object.
 	 *
-	 * @return  \Joomla\Database\Postgresql\PostgresqlQuery  The current query object or a new object extending the Query class.
+	 * @return  PostgresqlQuery  The current query object or a new object extending the Query class.
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
@@ -379,29 +388,29 @@ class PostgresqlDriver extends DatabaseDriver
 		$tableSub = $this->replacePrefix($table);
 
 		$this->setQuery('
-				SELECT a.attname AS "column_name",
-					pg_catalog.format_type(a.atttypid, a.atttypmod) as "type",
-					CASE WHEN a.attnotnull IS TRUE
-						THEN \'NO\'
-						ELSE \'YES\'
-					END AS "null",
-					CASE WHEN pg_catalog.pg_get_expr(adef.adbin, adef.adrelid, true) IS NOT NULL
-						THEN pg_catalog.pg_get_expr(adef.adbin, adef.adrelid, true)
-					END as "Default",
-					CASE WHEN pg_catalog.col_description(a.attrelid, a.attnum) IS NULL
-					THEN \'\'
-					ELSE pg_catalog.col_description(a.attrelid, a.attnum)
-					END  AS "comments"
-				FROM pg_catalog.pg_attribute a
-				LEFT JOIN pg_catalog.pg_attrdef adef ON a.attrelid=adef.adrelid AND a.attnum=adef.adnum
-				LEFT JOIN pg_catalog.pg_type t ON a.atttypid=t.oid
-				WHERE a.attrelid =
-					(SELECT oid FROM pg_catalog.pg_class WHERE relname=' . $this->quote($tableSub) . '
-						AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE
-						nspname = \'public\')
-					)
-				AND a.attnum > 0 AND NOT a.attisdropped
-				ORDER BY a.attnum'
+			SELECT a.attname AS "column_name",
+				pg_catalog.format_type(a.atttypid, a.atttypmod) as "type",
+				CASE WHEN a.attnotnull IS TRUE
+					THEN \'NO\'
+					ELSE \'YES\'
+				END AS "null",
+				CASE WHEN pg_catalog.pg_get_expr(adef.adbin, adef.adrelid, true) IS NOT NULL
+					THEN pg_catalog.pg_get_expr(adef.adbin, adef.adrelid, true)
+				END as "Default",
+				CASE WHEN pg_catalog.col_description(a.attrelid, a.attnum) IS NULL
+				THEN \'\'
+				ELSE pg_catalog.col_description(a.attrelid, a.attnum)
+				END  AS "comments"
+			FROM pg_catalog.pg_attribute a
+			LEFT JOIN pg_catalog.pg_attrdef adef ON a.attrelid=adef.adrelid AND a.attnum=adef.adnum
+			LEFT JOIN pg_catalog.pg_type t ON a.atttypid=t.oid
+			WHERE a.attrelid =
+				(SELECT oid FROM pg_catalog.pg_class WHERE relname=' . $this->quote($tableSub) . '
+					AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE
+					nspname = \'public\')
+				)
+			AND a.attnum > 0 AND NOT a.attisdropped
+			ORDER BY a.attnum'
 		);
 
 		$fields = $this->loadObjectList();
@@ -454,16 +463,16 @@ class PostgresqlDriver extends DatabaseDriver
 		{
 			// Get the details columns information.
 			$this->setQuery('
-					SELECT indexname AS "idxName", indisprimary AS "isPrimary", indisunique  AS "isUnique",
-						CASE WHEN indisprimary = true THEN
-							( SELECT \'ALTER TABLE \' || tablename || \' ADD \' || pg_catalog.pg_get_constraintdef(const.oid, true)
-								FROM pg_constraint AS const WHERE const.conname= pgClassFirst.relname )
-						ELSE pg_catalog.pg_get_indexdef(indexrelid, 0, true)
-						END AS "Query"
-					FROM pg_indexes
-					LEFT JOIN pg_class AS pgClassFirst ON indexname=pgClassFirst.relname
-					LEFT JOIN pg_index AS pgIndex ON pgClassFirst.oid=pgIndex.indexrelid
-					WHERE tablename=' . $this->quote($table) . ' ORDER BY indkey'
+				SELECT indexname AS "idxName", indisprimary AS "isPrimary", indisunique  AS "isUnique",
+					CASE WHEN indisprimary = true THEN
+						( SELECT \'ALTER TABLE \' || tablename || \' ADD \' || pg_catalog.pg_get_constraintdef(const.oid, true)
+							FROM pg_constraint AS const WHERE const.conname= pgClassFirst.relname )
+					ELSE pg_catalog.pg_get_indexdef(indexrelid, 0, true)
+					END AS "Query"
+				FROM pg_indexes
+				LEFT JOIN pg_class AS pgClassFirst ON indexname=pgClassFirst.relname
+				LEFT JOIN pg_index AS pgIndex ON pgClassFirst.oid=pgIndex.indexrelid
+				WHERE tablename=' . $this->quote($table) . ' ORDER BY indkey'
 			);
 			$keys = $this->loadObjectList();
 
@@ -487,12 +496,12 @@ class PostgresqlDriver extends DatabaseDriver
 
 		$query = $this->getQuery(true);
 		$query->select('table_name')
-				->from('information_schema.tables')
-				->where('table_type=' . $this->quote('BASE TABLE'))
-				->where(
-					'table_schema NOT IN (' . $this->quote('pg_catalog') . ', ' . $this->quote('information_schema') . ')'
-				)
-				->order('table_name ASC');
+			->from('information_schema.tables')
+			->where('table_type=' . $this->quote('BASE TABLE'))
+			->where(
+				'table_schema NOT IN (' . $this->quote('pg_catalog') . ', ' . $this->quote('information_schema') . ')'
+			)
+			->order('table_name ASC');
 
 		$this->setQuery($query);
 		$tables = $this->loadColumn();
@@ -533,13 +542,13 @@ class PostgresqlDriver extends DatabaseDriver
 			// Get the details columns information.
 			$query = $this->getQuery(true);
 			$query->select($this->quoteName($name, $as))
-					->from('pg_class AS s')
-					->leftJoin("pg_depend d ON d.objid=s.oid AND d.classid='pg_class'::regclass AND d.refclassid='pg_class'::regclass")
-					->leftJoin('pg_class t ON t.oid=d.refobjid')
-					->leftJoin('pg_namespace n ON n.oid=t.relnamespace')
-					->leftJoin('pg_attribute a ON a.attrelid=t.oid AND a.attnum=d.refobjsubid')
-					->leftJoin('information_schema.sequences AS info ON info.sequence_name=s.relname')
-					->where("s.relkind='S' AND d.deptype='a' AND t.relname=" . $this->quote($table));
+				->from('pg_class AS s')
+				->leftJoin("pg_depend d ON d.objid=s.oid AND d.classid='pg_class'::regclass AND d.refclassid='pg_class'::regclass")
+				->leftJoin('pg_class t ON t.oid=d.refobjid')
+				->leftJoin('pg_namespace n ON n.oid=t.relnamespace')
+				->leftJoin('pg_attribute a ON a.attrelid=t.oid AND a.attnum=d.refobjsubid')
+				->leftJoin('information_schema.sequences AS info ON info.sequence_name=s.relname')
+				->where("s.relkind='S' AND d.deptype='a' AND t.relname=" . $this->quote($table));
 			$this->setQuery($query);
 			$seq = $this->loadObjectList();
 
@@ -603,13 +612,13 @@ class PostgresqlDriver extends DatabaseDriver
 		/* find sequence column name */
 		$colNameQuery = $this->getQuery(true);
 		$colNameQuery->select('column_default')
-						->from('information_schema.columns')
-						->where(
-								"table_name=" . $this->quote(
-									$this->replacePrefix(str_replace('"', '', $table[0]))
-								), 'AND'
-						)
-						->where("column_default LIKE '%nextval%'");
+			->from('information_schema.columns')
+			->where(
+				"table_name=" . $this->quote(
+					$this->replacePrefix(str_replace('"', '', $table[0]))
+				), 'AND'
+			)
+			->where("column_default LIKE '%nextval%'");
 
 		$this->setQuery($colNameQuery);
 		$colName = $this->loadRow();
@@ -773,13 +782,13 @@ class PostgresqlDriver extends DatabaseDriver
 		{
 			/* Rename indexes */
 			$this->setQuery(
-							'SELECT relname
-								FROM pg_class
-								WHERE oid IN (
-									SELECT indexrelid
-									FROM pg_index, pg_class
-									WHERE pg_class.relname=' . $this->quote($oldTable, true) . '
-									AND pg_class.oid=pg_index.indrelid );'
+				'SELECT relname
+					FROM pg_class
+					WHERE oid IN (
+						SELECT indexrelid
+						FROM pg_index, pg_class
+						WHERE pg_class.relname=' . $this->quote($oldTable, true) . '
+						AND pg_class.oid=pg_index.indrelid );'
 			);
 
 			$oldIndexes = $this->loadColumn();
@@ -793,16 +802,16 @@ class PostgresqlDriver extends DatabaseDriver
 
 			/* Rename sequence */
 			$this->setQuery(
-							'SELECT relname
-								FROM pg_class
-								WHERE relkind = \'S\'
-								AND relnamespace IN (
-									SELECT oid
-									FROM pg_namespace
-									WHERE nspname NOT LIKE \'pg_%\'
-									AND nspname != \'information_schema\'
-								)
-								AND relname LIKE \'%' . $oldTable . '%\' ;'
+				'SELECT relname
+					FROM pg_class
+					WHERE relkind = \'S\'
+					AND relnamespace IN (
+						SELECT oid
+						FROM pg_namespace
+						WHERE nspname NOT LIKE \'pg_%\'
+						AND nspname != \'information_schema\'
+					)
+					AND relname LIKE \'%' . $oldTable . '%\' ;'
 			);
 
 			$oldSequences = $this->loadColumn();
@@ -1103,8 +1112,8 @@ class PostgresqlDriver extends DatabaseDriver
 		$query = $this->getQuery(true);
 
 		$query->insert($this->quoteName($table))
-				->columns($fields)
-				->values(implode(',', $values));
+			->columns($fields)
+			->values(implode(',', $values));
 
 		$retVal = false;
 
@@ -1162,11 +1171,11 @@ class PostgresqlDriver extends DatabaseDriver
 
 		$query = $this->getQuery(true);
 		$query->select('table_name')
-				->from('information_schema.tables')
-				->where('table_type=' . $this->quote('BASE TABLE'))
-				->where(
-					'table_schema NOT IN (' . $this->quote('pg_catalog') . ', ' . $this->quote('information_schema') . ' )'
-				);
+			->from('information_schema.tables')
+			->where('table_type=' . $this->quote('BASE TABLE'))
+			->where(
+				'table_schema NOT IN (' . $this->quote('pg_catalog') . ', ' . $this->quote('information_schema') . ' )'
+			);
 
 		$this->setQuery($query);
 		$tableList = $this->loadColumn();

--- a/src/Joomla/Database/Postgresql/PostgresqlExporter.php
+++ b/src/Joomla/Database/Postgresql/PostgresqlExporter.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Postgresql;
 use Joomla\Database\DatabaseExporter;
 
 /**
- * PostgreSQL export driver.
+ * PostgreSQL Database Exporter.
  *
  * @since  1.0
  */
@@ -112,13 +112,13 @@ class PostgresqlExporter extends DatabaseExporter
 		// Check if the db connector has been set.
 		if (!($this->db instanceof PostgresqlDriver))
 		{
-			throw new \Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
+			throw new \Exception('Database connection wrong type.');
 		}
 
 		// Check if the tables have been specified.
 		if (empty($this->from))
 		{
-			throw new \Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
+			throw new \Exception('ERROR: No Tables Specified');
 		}
 
 		return $this;

--- a/src/Joomla/Database/Postgresql/PostgresqlImporter.php
+++ b/src/Joomla/Database/Postgresql/PostgresqlImporter.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Postgresql;
 use Joomla\Database\DatabaseImporter;
 
 /**
- * PostgreSQL import driver.
+ * PostgreSQL Database Importer.
  *
  * @since  1.0
  */
@@ -30,13 +30,13 @@ class PostgresqlImporter extends DatabaseImporter
 		// Check if the db connector has been set.
 		if (!($this->db instanceof PostgresqlDriver))
 		{
-			throw new \Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
+			throw new \Exception('Database connection wrong type.');
 		}
 
 		// Check if the tables have been specified.
 		if (empty($this->from))
 		{
-			throw new \Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
+			throw new \Exception('ERROR: No Tables Specified');
 		}
 
 		return $this;
@@ -106,7 +106,7 @@ class PostgresqlImporter extends DatabaseImporter
 				// The field exists, check it's the same.
 				$column = $oldSeq[$kSeqName][0];
 
-				/* For older database version that doesn't support these fields use default values */
+				// For older database version that doesn't support these fields use default values
 				if (version_compare($this->db->getVersion(), '9.1.0') < 0)
 				{
 					$column->Min_Value = '1';
@@ -287,13 +287,11 @@ class PostgresqlImporter extends DatabaseImporter
 			$field['Start_Value'] = '1';
 		}
 
-		$sql = 'CREATE SEQUENCE ' . (string) $field['Name'] .
-				' INCREMENT BY ' . (string) $field['Increment'] . ' MINVALUE ' . $field['Min_Value'] .
-				' MAXVALUE ' . (string) $field['Max_Value'] . ' START ' . (string) $field['Start_Value'] .
-				(((string) $field['Cycle_option'] == 'NO' ) ? ' NO' : '' ) . ' CYCLE' .
-				' OWNED BY ' . $this->db->quoteName(
-									(string) $field['Schema'] . '.' . (string) $field['Table'] . '.' . (string) $field['Column']
-								);
+		$sql = 'CREATE SEQUENCE ' . (string) $field['Name']
+			. ' INCREMENT BY ' . (string) $field['Increment'] . ' MINVALUE ' . $field['Min_Value']
+			. ' MAXVALUE ' . (string) $field['Max_Value'] . ' START ' . (string) $field['Start_Value']
+			. (((string) $field['Cycle_option'] == 'NO' ) ? ' NO' : '' ) . ' CYCLE'
+			. ' OWNED BY ' . $this->db->quoteName((string) $field['Schema'] . '.' . (string) $field['Table'] . '.' . (string) $field['Column']);
 
 		return $sql;
 	}
@@ -319,12 +317,10 @@ class PostgresqlImporter extends DatabaseImporter
 			$field['Start_Value'] = '1';
 		}
 
-		$sql = 'ALTER SEQUENCE ' . (string) $field['Name'] .
-				' INCREMENT BY ' . (string) $field['Increment'] . ' MINVALUE ' . (string) $field['Min_Value'] .
-				' MAXVALUE ' . (string) $field['Max_Value'] . ' START ' . (string) $field['Start_Value'] .
-				' OWNED BY ' . $this->db->quoteName(
-									(string) $field['Schema'] . '.' . (string) $field['Table'] . '.' . (string) $field['Column']
-								);
+		$sql = 'ALTER SEQUENCE ' . (string) $field['Name']
+			. ' INCREMENT BY ' . (string) $field['Increment'] . ' MINVALUE ' . (string) $field['Min_Value']
+			. ' MAXVALUE ' . (string) $field['Max_Value'] . ' START ' . (string) $field['Start_Value']
+			. ' OWNED BY ' . $this->db->quoteName((string) $field['Schema'] . '.' . (string) $field['Table'] . '.' . (string) $field['Column']);
 
 		return $sql;
 	}
@@ -366,7 +362,7 @@ class PostgresqlImporter extends DatabaseImporter
 		$fType = (string) $field['Type'];
 		$fNull = (string) $field['Null'];
 		$fDefault = (isset($field['Default']) && $field['Default'] != 'NULL' ) ?
-						preg_match('/^[0-9]$/', $field['Default']) ? $field['Default'] : $this->db->quote((string) $field['Default'])
+					preg_match('/^[0-9]$/', $field['Default']) ? $field['Default'] : $this->db->quote((string) $field['Default'])
 					: null;
 
 		$sql = ' TYPE ' . $fType;
@@ -375,25 +371,25 @@ class PostgresqlImporter extends DatabaseImporter
 		{
 			if (in_array($fType, $blobs) || $fDefault === null)
 			{
-				$sql .= ",\nALTER COLUMN " . $this->db->quoteName($fName) . ' SET NOT NULL' .
-						",\nALTER COLUMN " . $this->db->quoteName($fName) . ' DROP DEFAULT';
+				$sql .= ",\nALTER COLUMN " . $this->db->quoteName($fName) . ' SET NOT NULL'
+					. ",\nALTER COLUMN " . $this->db->quoteName($fName) . ' DROP DEFAULT';
 			}
 			else
 			{
-				$sql .= ",\nALTER COLUMN " . $this->db->quoteName($fName) . ' SET NOT NULL' .
-						",\nALTER COLUMN " . $this->db->quoteName($fName) . ' SET DEFAULT ' . $fDefault;
+				$sql .= ",\nALTER COLUMN " . $this->db->quoteName($fName) . ' SET NOT NULL'
+					. ",\nALTER COLUMN " . $this->db->quoteName($fName) . ' SET DEFAULT ' . $fDefault;
 			}
 		}
 		else
 		{
 			if ($fDefault !== null)
 			{
-				$sql .= ",\nALTER COLUMN " . $this->db->quoteName($fName) . ' DROP NOT NULL' .
-						",\nALTER COLUMN " . $this->db->quoteName($fName) . ' SET DEFAULT ' . $fDefault;
+				$sql .= ",\nALTER COLUMN " . $this->db->quoteName($fName) . ' DROP NOT NULL'
+					. ",\nALTER COLUMN " . $this->db->quoteName($fName) . ' SET DEFAULT ' . $fDefault;
 			}
 		}
 
-		/* sequence was created in other function, here is associated a default value but not yet owner */
+		// Sequence was created in other function, here is associated a default value but not yet owner
 		if (strpos($fDefault, 'nextval') !== false)
 		{
 			$sql .= ";\nALTER SEQUENCE " . $this->db->quoteName($table . '_' . $fName . '_seq') . ' OWNED BY ' . $this->db->quoteName($table . '.' . $fName);
@@ -420,10 +416,10 @@ class PostgresqlImporter extends DatabaseImporter
 		$fType = (string) $field['Type'];
 		$fNull = (string) $field['Null'];
 		$fDefault = (isset($field['Default']) && $field['Default'] != 'NULL' ) ?
-						preg_match('/^[0-9]$/', $field['Default']) ? $field['Default'] : $this->db->quote((string) $field['Default'])
+					preg_match('/^[0-9]$/', $field['Default']) ? $field['Default'] : $this->db->quote((string) $field['Default'])
 					: null;
 
-		/* nextval() as default value means that type field is serial */
+		// nextval() as default value means that type field is serial
 		if (strpos($fDefault, 'nextval') !== false)
 		{
 			$sql = $this->db->quoteName($fName) . ' SERIAL';

--- a/src/Joomla/Database/Postgresql/PostgresqlIterator.php
+++ b/src/Joomla/Database/Postgresql/PostgresqlIterator.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Postgresql;
 use Joomla\Database\DatabaseIterator;
 
 /**
- * PostgreSQL database iterator.
+ * PostgreSQL Database Iterator.
  *
  * @since  1.0
  */

--- a/src/Joomla/Database/Postgresql/PostgresqlQuery.php
+++ b/src/Joomla/Database/Postgresql/PostgresqlQuery.php
@@ -13,50 +13,62 @@ use Joomla\Database\Query\QueryElement;
 use Joomla\Database\Query\LimitableInterface;
 
 /**
- * Query Building Class.
+ * PostgreSQL Query Building Class.
  *
  * @since  1.0
  */
 class PostgresqlQuery extends DatabaseQuery implements LimitableInterface
 {
 	/**
-	 * @var    object  The FOR UPDATE element used in "FOR UPDATE"  lock
+	 * The FOR UPDATE element used in "FOR UPDATE" lock
+	 *
+	 * @var    object
 	 * @since  1.0
 	 */
 	protected $forUpdate = null;
 
 	/**
-	 * @var    object  The FOR SHARE element used in "FOR SHARE"  lock
+	 * The FOR SHARE element used in "FOR SHARE" lock
+	 *
+	 * @var    object
 	 * @since  1.0
 	 */
 	protected $forShare = null;
 
 	/**
-	 * @var    object  The NOWAIT element used in "FOR SHARE" and "FOR UPDATE" lock
+	 * The NOWAIT element used in "FOR SHARE" and "FOR UPDATE" lock
+	 *
+	 * @var    object
 	 * @since  1.0
 	 */
 	protected $noWait = null;
 
 	/**
-	 * @var    object  The LIMIT element
+	 * The LIMIT element
+	 *
+	 * @var    object
 	 * @since  1.0
 	 */
 	protected $limit = null;
 
 	/**
-	 * @var    object  The OFFSET element
+	 * The OFFSET element
+	 *
+	 * @var    object
 	 * @since  1.0
 	 */
 	protected $offset = null;
 
 	/**
-	 * @var    object  The RETURNING element of INSERT INTO
+	 * The RETURNING element of INSERT INTO
+	 *
+	 * @var    object
 	 * @since  1.0
 	 */
 	protected $returning = null;
 
 	/**
-	 * Magic function to convert the query to a string, only for postgresql specific query
+	 * Magic function to convert the query to a string, only for PostgreSQL specific queries
 	 *
 	 * @return  string	The completed query.
 	 *
@@ -323,7 +335,7 @@ class PostgresqlQuery extends DatabaseQuery implements LimitableInterface
 	 *
 	 * @since   1.0
 	 */
-	public function forUpdate ($table_name, $glue = ',')
+	public function forUpdate($table_name, $glue = ',')
 	{
 		$this->type = 'forUpdate';
 
@@ -350,7 +362,7 @@ class PostgresqlQuery extends DatabaseQuery implements LimitableInterface
 	 *
 	 * @since   1.0
 	 */
-	public function forShare ($table_name, $glue = ',')
+	public function forShare($table_name, $glue = ',')
 	{
 		$this->type = 'forShare';
 
@@ -491,7 +503,7 @@ class PostgresqlQuery extends DatabaseQuery implements LimitableInterface
 	/**
 	 * Set the LIMIT clause to the query
 	 *
-	 * @param   int  $limit  An int of how many row will be returned
+	 * @param   integer  $limit  Number of rows to return
 	 *
 	 * @return  PostgresqlQuery  Returns this object to allow chaining.
 	 *
@@ -510,7 +522,7 @@ class PostgresqlQuery extends DatabaseQuery implements LimitableInterface
 	/**
 	 * Set the OFFSET clause to the query
 	 *
-	 * @param   int  $offset  An int for skipping row
+	 * @param   integer  $offset  An integer for skipping rows
 	 *
 	 * @return  PostgresqlQuery  Returns this object to allow chaining.
 	 *

--- a/src/Joomla/Database/Query/PreparableInterface.php
+++ b/src/Joomla/Database/Query/PreparableInterface.php
@@ -10,6 +10,7 @@ namespace Joomla\Database\Query;
 
 /**
  * Joomla Database Query Preparable Interface.
+ *
  * Adds bind/unbind methods as well as a getBounded() method
  * to retrieve the stored bounded variables on demand prior to
  * query execution.

--- a/src/Joomla/Database/Sqlazure/SqlazureDriver.php
+++ b/src/Joomla/Database/Sqlazure/SqlazureDriver.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Sqlazure;
 use Joomla\Database\Sqlsrv\SqlsrvDriver;
 
 /**
- * SQL Server database driver
+ * SQL Azure Database Driver
  *
  * @see    http://msdn.microsoft.com/en-us/library/ee336279.aspx
  * @since  1.0

--- a/src/Joomla/Database/Sqlazure/SqlazureIterator.php
+++ b/src/Joomla/Database/Sqlazure/SqlazureIterator.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Sqlazure;
 use Joomla\Database\Sqlsrv\SqlsrvIterator;
 
 /**
- * SQL azure database iterator.
+ * SQL Azure Database Iterator.
  *
  * @since  1.0
  */

--- a/src/Joomla/Database/Sqlazure/SqlazureQuery.php
+++ b/src/Joomla/Database/Sqlazure/SqlazureQuery.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Sqlazure;
 use Joomla\Database\Sqlsrv\SqlsrvQuery;
 
 /**
- * Query Building Class.
+ * SQL Azure Query Building Class.
  *
  * @since  1.0
  */
@@ -24,7 +24,6 @@ class SqlazureQuery extends SqlsrvQuery
 	 * used for the opening quote and the second for the closing quote.
 	 *
 	 * @var    string
-	 *
 	 * @since  1.0
 	 */
 	protected $name_quotes = '';

--- a/src/Joomla/Database/Sqlite/SqliteDriver.php
+++ b/src/Joomla/Database/Sqlite/SqliteDriver.php
@@ -12,9 +12,9 @@ use Sqlite3;
 use Joomla\Database\Pdo\PdoDriver;
 
 /**
- * SQLite database driver
+ * SQLite database driver supporting PDO based connections
  *
- * @see    http://php.net/pdo
+ * @see    http://php.net/manual/en/ref.pdo-sqlite.php
  * @since  1.0
  */
 class SqliteDriver extends PdoDriver
@@ -88,8 +88,7 @@ class SqliteDriver extends PdoDriver
 	/**
 	 * Method to escape a string for usage in an SQLite statement.
 	 *
-	 * Note: Using query objects with bound variables is
-	 * preferable to the below.
+	 * Note: Using query objects with bound variables is preferable to the below.
 	 *
 	 * @param   string   $text   The string to be escaped.
 	 * @param   boolean  $extra  Unused optional parameter to provide extra escaping.
@@ -253,6 +252,7 @@ class SqliteDriver extends PdoDriver
 	{
 		$this->connect();
 
+		/* @type  SqliteQuery  $query */
 		$query = $this->getQuery(true);
 
 		$type = 'table';
@@ -451,15 +451,17 @@ class SqliteDriver extends PdoDriver
 
 		if (!$asSavepoint || !$this->transactionDepth)
 		{
-			return parent::transactionStart($asSavepoint);
+			parent::transactionStart($asSavepoint);
 		}
-
-		$savepoint = 'SP_' . $this->transactionDepth;
-		$this->setQuery('SAVEPOINT ' . $this->quoteName($savepoint));
-
-		if ($this->execute())
+		else
 		{
-			$this->transactionDepth++;
+			$savepoint = 'SP_' . $this->transactionDepth;
+			$this->setQuery('SAVEPOINT ' . $this->quoteName($savepoint));
+
+			if ($this->execute())
+			{
+				$this->transactionDepth++;
+			}
 		}
 	}
 }

--- a/src/Joomla/Database/Sqlite/SqliteIterator.php
+++ b/src/Joomla/Database/Sqlite/SqliteIterator.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Sqlite;
 use Joomla\Database\Pdo\PdoIterator;
 
 /**
- * SQLite database iterator.
+ * SQLite Database Iterator.
  *
  * @since  1.0
  */

--- a/src/Joomla/Database/Sqlite/SqliteQuery.php
+++ b/src/Joomla/Database/Sqlite/SqliteQuery.php
@@ -20,19 +20,25 @@ use Joomla\Database\Query\LimitableInterface;
 class SqliteQuery extends PdoQuery implements PreparableInterface, LimitableInterface
 {
 	/**
-	 * @var    integer  The limit for the result set.
+	 * The limit for the result set.
+	 *
+	 * @var    integer
 	 * @since  1.0
 	 */
 	protected $limit;
 
 	/**
-	 * @var    integer  The offset for the result set.
+	 * The offset for the result set.
+	 *
+	 * @var    integer
 	 * @since  1.0
 	 */
 	protected $offset;
 
 	/**
-	 * @var    mixed  Holds key / value pair of bound objects.
+	 * Holds key / value pair of bound objects.
+	 *
+	 * @var    mixed
 	 * @since  1.0
 	 */
 	protected $bounded = array();
@@ -49,7 +55,7 @@ class SqliteQuery extends PdoQuery implements PreparableInterface, LimitableInte
 	 * @param   integer         $length         The length of the variable. Usually required for OUTPUT parameters.
 	 * @param   array           $driverOptions  Optional driver options to be used.
 	 *
-	 * @return  SqliteQuery
+	 * @return  SqliteQuery  Returns this object to allow chaining.
 	 *
 	 * @since   1.0
 	 */
@@ -130,9 +136,7 @@ class SqliteQuery extends PdoQuery implements PreparableInterface, LimitableInte
 				break;
 		}
 
-		parent::clear($clause);
-
-		return $this;
+		return parent::clear($clause);
 	}
 
 	/**

--- a/src/Joomla/Database/Sqlsrv/SqlsrvDriver.php
+++ b/src/Joomla/Database/Sqlsrv/SqlsrvDriver.php
@@ -12,9 +12,9 @@ use Psr\Log;
 use Joomla\Database\DatabaseDriver;
 
 /**
- * SQL Server database driver
+ * SQL Server Database Driver
  *
- * @see    http://msdn.microsoft.com/en-us/library/cc296152(SQL.90).aspx
+ * @see    http://php.net/manual/en/book.sqlsrv.php
  * @since  1.0
  */
 class SqlsrvDriver extends DatabaseDriver
@@ -48,7 +48,9 @@ class SqlsrvDriver extends DatabaseDriver
 	protected $nullDate = '1900-01-01 00:00:00';
 
 	/**
-	 * @var    string  The minimum supported database version.
+	 * The minimum supported database version.
+	 *
+	 * @var    string
 	 * @since  1.0
 	 */
 	protected static $dbMinimum = '10.50.1600.1';
@@ -122,7 +124,7 @@ class SqlsrvDriver extends DatabaseDriver
 			'ReturnDatesAsStrings' => true);
 
 		// Make sure the SQLSRV extension for PHP is installed and enabled.
-		if (!function_exists('sqlsrv_connect'))
+		if (!static::isSupported())
 		{
 			throw new \RuntimeException('PHP extension sqlsrv_connect is not available.');
 		}
@@ -174,10 +176,8 @@ class SqlsrvDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		$query = $this->getQuery(true);
-
 		$this->setQuery(
-			'SELECT CONSTRAINT_NAME FROM' . ' INFORMATION_SCHEMA.TABLE_CONSTRAINTS' . ' WHERE TABLE_NAME = ' . $query->quote($tableName)
+			'SELECT CONSTRAINT_NAME FROM' . ' INFORMATION_SCHEMA.TABLE_CONSTRAINTS' . ' WHERE TABLE_NAME = ' . $this->quote($tableName)
 		);
 
 		return $this->loadColumn();
@@ -266,7 +266,7 @@ class SqlsrvDriver extends DatabaseDriver
 		if ($ifExists)
 		{
 			$this->setQuery(
-				'IF EXISTS(SELECT TABLE_NAME FROM' . ' INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = ' . $query->quote($tableName) . ') DROP TABLE ' . $tableName
+				'IF EXISTS(SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = ' . $query->quote($tableName) . ') DROP TABLE ' . $tableName
 			);
 		}
 		else
@@ -445,7 +445,7 @@ class SqlsrvDriver extends DatabaseDriver
 	 * @param   object  &$object  A reference to an object whose public properties match the table fields.
 	 * @param   string  $key      The name of the primary key. If provided the object property is updated.
 	 *
-	 * @return  boolean    True on success.
+	 * @return  boolean  True on success.
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException

--- a/src/Joomla/Database/Sqlsrv/SqlsrvIterator.php
+++ b/src/Joomla/Database/Sqlsrv/SqlsrvIterator.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Sqlsrv;
 use Joomla\Database\DatabaseIterator;
 
 /**
- * SQL server database iterator.
+ * SQL Server Database Iterator.
  *
  * @since  1.0
  */
@@ -33,7 +33,7 @@ class SqlsrvIterator extends DatabaseIterator
 	/**
 	 * Method to fetch a row from the result set cursor as an object.
 	 *
-	 * @return  mixed   Either the next row from the result set or false if there are no more rows.
+	 * @return  mixed  Either the next row from the result set or false if there are no more rows.
 	 *
 	 * @since   1.0
 	 */

--- a/src/Joomla/Database/Sqlsrv/SqlsrvQuery.php
+++ b/src/Joomla/Database/Sqlsrv/SqlsrvQuery.php
@@ -11,7 +11,7 @@ namespace Joomla\Database\Sqlsrv;
 use Joomla\Database\DatabaseQuery;
 
 /**
- * Query Building Class.
+ * SQL Server Query Building Class.
  *
  * @since  1.0
  */
@@ -24,7 +24,6 @@ class SqlsrvQuery extends DatabaseQuery
 	 * used for the opening quote and the second for the closing quote.
 	 *
 	 * @var    string
-	 *
 	 * @since  1.0
 	 */
 	protected $name_quotes = '`';
@@ -34,7 +33,6 @@ class SqlsrvQuery extends DatabaseQuery
 	 * defined in child classes to hold the appropriate value for the engine.
 	 *
 	 * @var    string
-	 *
 	 * @since  1.0
 	 */
 	protected $null_date = '1900-01-01 00:00:00';


### PR DESCRIPTION
- Fixing up some doc block text based on reviewing `phpdoc` output
- Consistent formatting of doc blocks in classes
- PhpStorm inspector - Methods declared returning void should not return a value (transaction methods in Database packages)
- Some code style stuff
