### PR TITLE
Fix response of getRateLimit for enterprise servers

### DIFF
--- a/src/Joomla/Github/Package/Authorization.php
+++ b/src/Joomla/Github/Package/Authorization.php
@@ -220,7 +220,8 @@ class Authorization extends Package
 	/**
 	 * Method to get the rate limit for the authenticated user.
 	 *
-	 * @return  object
+	 * @return  object  Returns an object with the properties of `limit` and `remaining`. If there is no limit, the
+	 *                  `limit` property will be false.
 	 *
 	 * @since   1.0
 	 * @throws  \DomainException
@@ -236,6 +237,12 @@ class Authorization extends Package
 		// Validate the response code.
 		if ($response->code != 200)
 		{
+			if ($response->code == 404)
+			{
+				// Unlimited rate for Github Enterprise sites and trusted users.
+				return (object) array('limit' => false, 'remaining' => null);
+			}
+
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
 			throw new \DomainException($error->message, $response->code);

--- a/src/Joomla/Github/Tests/Package/AuthorizationsTest.php
+++ b/src/Joomla/Github/Tests/Package/AuthorizationsTest.php
@@ -448,6 +448,26 @@ class AuthorizationsTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Tests the getRateLimit method for an unlimited user.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetRateLimit_unlimited()
+	{
+		$this->response->code = 404;
+		$this->response->body = '';
+
+		$this->client->expects($this->once())
+					 ->method('get')
+					 ->with('/rate_limit')
+					 ->will($this->returnValue($this->response));
+
+		$this->assertFalse($this->object->getRateLimit()->limit, 'The limit should be false for unlimited');
+	}
+
+	/**
 	 * Tests the getRateLimit method - failure
 	 *
 	 * @return  void


### PR DESCRIPTION
Github Enterprise allows for unlimited rates. If so, the limit will
return false (will update the docs when my other PR is merged).
