### PR TITLE
Archive exception message fix and make the tests run

### DIFF
--- a/src/Joomla/Archive/Archive.php
+++ b/src/Joomla/Archive/Archive.php
@@ -160,7 +160,13 @@ class Archive
 	{
 		if (!($class instanceof ExtractableInterface))
 		{
-			throw new \InvalidArgumentException(sprintf('The provided %s adapter %s must implement Joomla\\Archive\\ExtractableInterface', $type), 500);
+			throw new \InvalidArgumentException(
+				sprintf(
+					'The provided adapter "%s" (class "%s") must implement Joomla\\Archive\\ExtractableInterface',
+					$type,
+					$class
+				)
+			);
 		}
 
 		if ($override || !isset($this->adapters[$type]))
@@ -179,7 +185,7 @@ class Archive
 	 * @return  ExtractableInterface  Adapter for the requested type
 	 *
 	 * @since   1.0
-	 * @throws  \UnexpectedValueException
+	 * @throws  \InvalidArgumentException
 	 */
 	public function getAdapter($type)
 	{
@@ -193,7 +199,13 @@ class Archive
 
 			if (!class_exists($class) || !$class::isSupported())
 			{
-				throw new \UnexpectedValueException(sprintf('Archive adapter %s not found or supported.', $type), 500);
+				throw new \InvalidArgumentException(
+					sprintf(
+						'Archive adapter "%s" (class "%s") not found or supported.',
+						$type,
+						$class
+					)
+				);
 			}
 
 			$this->adapters[$type] = new $class($this->options);

--- a/src/Joomla/Archive/Tests/ArchiveTest.php
+++ b/src/Joomla/Archive/Tests/ArchiveTest.php
@@ -225,16 +225,76 @@ class ArchiveTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test...
+	 * Test getAdapter exception.
 	 *
-	 * @return  mixed
+	 * @return  void
 	 *
 	 * @covers             Joomla\Archive\Archive::getAdapter
-	 * @expectedException  \UnexpectedValueException
+	 * @expectedException  \InvalidArgumentException
 	 * @since              1.0
 	 */
 	public function testGetAdapterException()
 	{
 		$this->fixture->getAdapter('unknown');
+	}
+
+	/**
+	 * Test getAdapter exception message.
+	 *
+	 * @return  void
+	 *
+	 * @since  1.0
+	 */
+	public function testGetAdapterExceptionMessage()
+	{
+		try
+		{
+			$this->fixture->getAdapter('unknown');
+		}
+
+		catch (\InvalidArgumentException $e)
+		{
+			$this->assertEquals(
+				'Archive adapter "unknown" (class "Joomla\\Archive\\Unknown") not found or supported.',
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Test setAdapter exception.
+	 *
+	 * @return  void
+	 *
+	 * @covers             Joomla\Archive\Archive::setAdapter
+	 * @expectedException  \InvalidArgumentException
+	 * @since              1.0
+	 */
+	public function testSetAdapterException()
+	{
+		$this->fixture->setAdapter('unknown', 'unknown-class');
+	}
+
+	/**
+	 * Test setAdapter exception message.
+	 *
+	 * @return  void
+	 *
+	 * @since  1.0
+	 */
+	public function testSetAdapterExceptionMessage()
+	{
+		try
+		{
+			$this->fixture->setAdapter('unknown', 'FooArchiveAdapter');
+		}
+
+		catch (\InvalidArgumentException $e)
+		{
+			$this->assertEquals(
+				'The provided adapter "unknown" (class "FooArchiveAdapter") must implement Joomla\\Archive\\ExtractableInterface',
+				$e->getMessage()
+			);
+		}
 	}
 }

--- a/src/Joomla/Archive/Tests/bootstrap.php
+++ b/src/Joomla/Archive/Tests/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Part of the Joomla Framework Archive Package
+ *
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+if (!defined('JPATH_ROOT'))
+{
+	define('JPATH_ROOT', __DIR__);
+}
+
+$autoload = __DIR__ . '/../vendor/autoload.php';
+
+if (file_exists($autoload))
+{
+	include_once $autoload;
+}

--- a/src/Joomla/Archive/phpunit.xml.dist
+++ b/src/Joomla/Archive/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php" colors="false">
+<phpunit bootstrap="Tests/bootstrap.php" colors="false">
 	<testsuites>
 		<testsuite name="Unit">
 			<directory>Tests</directory>


### PR DESCRIPTION
The package depends on `Filesystem` which depends on `JPATH_ROOT` so the `Archive` tests don't run alone.
Changed UnexpectedValueException to InvalidArgumentException because less appropriate.
