### PR TITLE
Make ArrayHelperTest resilient against undefined sort order

### DIFF
--- a/src/Joomla/Utilities/Tests/ArrayHelperTest.php
+++ b/src/Joomla/Utilities/Tests/ArrayHelperTest.php
@@ -732,7 +732,8 @@ class ArrayHelperTest extends PHPUnit_Framework_TestCase
 					),
 				),
 				'Should be sorted by the string field in ascending order full argument list',
-				false
+				false,
+				array(1, 2)
 			),
 			'by string descending' => array(
 				$input1,
@@ -767,7 +768,8 @@ class ArrayHelperTest extends PHPUnit_Framework_TestCase
 					),
 				),
 				'Should be sorted by the string field in descending order',
-				false
+				false,
+				array(5, 6)
 			),
 			'by casesensitive string ascending' => array(
 				$input2,
@@ -802,7 +804,8 @@ class ArrayHelperTest extends PHPUnit_Framework_TestCase
 					),
 				),
 				'Should be sorted by the string field in ascending order with casesensitive comparisons',
-				false
+				false,
+				array(1, 2)
 			),
 			'by casesensitive string descending' => array(
 				$input2,
@@ -837,7 +840,8 @@ class ArrayHelperTest extends PHPUnit_Framework_TestCase
 					),
 				),
 				'Should be sorted by the string field in descending order with casesensitive comparisons',
-				false
+				false,
+				array(5, 6)
 			),
 			'by casesensitive string,integer ascending' => array(
 				$input2,
@@ -1536,7 +1540,7 @@ class ArrayHelperTest extends PHPUnit_Framework_TestCase
 	 * @covers        Joomla\Utilities\ArrayHelper::sortObjects
 	 * @since         1.0
 	 */
-	public function testSortObjects($input, $key, $direction, $casesensitive, $locale, $expect, $message, $defaults)
+	public function testSortObjects($input, $key, $direction, $casesensitive, $locale, $expect, $message, $defaults, $swappable_keys = array())
 	{
 		// Convert the $locale param to a string if it is an array
 		if (is_array($locale))
@@ -1565,6 +1569,16 @@ class ArrayHelperTest extends PHPUnit_Framework_TestCase
 		else
 		{
 			$output = ArrayHelper::sortObjects($input, $key, $direction, $casesensitive, $locale);
+		}
+
+		// The ordering of elements that compare equal according to
+		// $key is undefined (implementation dependent).
+		if ($expect != $output && $swappable_keys) {
+			list($k1, $k2) = $swappable_keys;
+			$e1 = $output[$k1];
+			$e2 = $output[$k2];
+			$output[$k1] = $e2;
+			$output[$k2] = $e1;
 		}
 
 		$this->assertEquals($expect, $output, $message);


### PR DESCRIPTION
The documentation of usort (http://us1.php.net/manual/en/function.usort.php)
makes it clear that "If two members compare as equal, their relative order in the sorted array is undefined."
