### PR TITLE
Improvements to Application docs

### DIFF
--- a/src/Joomla/Application/README.md
+++ b/src/Joomla/Application/README.md
@@ -190,6 +190,54 @@ You can provide customised implementations these methods by creating the followi
 * `mockWebSetBody`
 * `mockWebSetHeader`
 
+
+## Web Application
+
+### Configuration options
+
+The `AbstractWebApplication` sets following application configuration:
+
+- Exection datetime and timestamp
+  - `execution.datetime` - Execution datetime
+  - `execution.timestamp` - Execution timestamp
+
+- URIs
+  - `uri.request` - The request URI
+  - `uri.base.full` - full URI
+  - `uri.base.host` - URI host
+  - `uri.base.path` - URI path
+  - `uri.route` - Extended (non-base) part of the request URI
+  - `uri.media.full` - full media URI
+  - `uri.media.path` - relative media URI
+
+and uses following ones during object construction:
+
+- `gzip` to compress the output
+- `site_uri` to see if an explicit base URI has been set
+  (helpful when chaning request uri using mod_rewrite)
+- `media_uri` to get an explicitly set media URI (relative values are appended to `uri.base` ).
+  If it's not set explicitly, it defaults to a `media/` path of `uri.base`.
+
+
+#### The `redirect` method
+__Accepted parameters__
+
+ - `$url` - The URL to redirect to. Can only be http/https URL
+ - `$moved` - True if the page is 301 Permanently Moved, otherwise 303 See Other is assumed.
+
+#### The `setHeader` method
+__Accepted parameters__
+
+- `$name` - The name of the header to set.
+- `$value` - The value of the header to set.
+- `$replace` - True to replace any headers with the same name.
+
+Example: Using `WebApplication::setHeader` to set a status header.
+
+```PHP
+$app->setHeader('status', '403 Forbidden', true);
+```
+
 ## Command Line Applications
 
 The Joomla Framework provides an application class for making command line applications.

--- a/src/Joomla/Application/README.md
+++ b/src/Joomla/Application/README.md
@@ -75,7 +75,7 @@ The following example shows how you could set up logging in your application usi
 
 ```php
 use Joomla\Application\AbstractApplication;
-use Monolog\Monolog;
+use Monolog\Logger;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 

--- a/src/Joomla/Application/README.md
+++ b/src/Joomla/Application/README.md
@@ -218,13 +218,6 @@ and uses following ones during object construction:
 - `media_uri` to get an explicitly set media URI (relative values are appended to `uri.base` ).
   If it's not set explicitly, it defaults to a `media/` path of `uri.base`.
 
-
-#### The `redirect` method
-__Accepted parameters__
-
- - `$url` - The URL to redirect to. Can only be http/https URL
- - `$moved` - True if the page is 301 Permanently Moved, otherwise 303 See Other is assumed.
-
 #### The `setHeader` method
 __Accepted parameters__
 
@@ -235,7 +228,12 @@ __Accepted parameters__
 Example: Using `WebApplication::setHeader` to set a status header.
 
 ```PHP
-$app->setHeader('status', '403 Forbidden', true);
+$app->setHeader('status', '401 Auhtorization required', true);
+```
+
+Will result in response containing header
+```
+Status Code: 401 Auhtorization required
 ```
 
 ## Command Line Applications

--- a/src/Joomla/Application/README.md
+++ b/src/Joomla/Application/README.md
@@ -39,7 +39,16 @@ class MyApplication extends AbstractApplication
 	 */
 	protected function doExecute()
 	{
-		// Do stuff.
+		try
+		{
+			// Do stuff.
+		}
+		catch(\Exception $e)
+		{
+			// Set status header of exception code and response body of exception message
+			$this->setHeader('status', $e->getCode() ?: 500);
+			$this->setBody($e->getMessage());
+		}
 	}
 
 	/**
@@ -197,7 +206,14 @@ class MyCli extends AbstractCliApplication
 {
 	protected function doExecute()
 	{
+		// Output string
 		$this->out('It works');
+
+		// Get user input
+		$this->out('What is your name? ', false);
+
+		$userInput = $this->in();
+		$this->out('Hello ' . $userInput);
 	}
 }
 


### PR DESCRIPTION
Described some things that are not obvious from the docblocks.

I'm confused, what is supposed to come into README.md's. Now we have
- There is an [API documentation](http://api.joomla.org/framework-1.0/index.html)
- Framework [GitHub page](http://joomla.github.io/joomla-framework/) with obsolete documentation
- [Experimental developer documentation](https://github.com/joomla/joomla-developer-docs) which is aggregating the README's and adding the Recipes
