### PR TITLE
DI: docblock fix

### DIFF
--- a/src/Joomla/DI/ServiceProviderInterface.php
+++ b/src/Joomla/DI/ServiceProviderInterface.php
@@ -20,7 +20,7 @@ interface ServiceProviderInterface
 	 *
 	 * @param   Container  $container  The DI container.
 	 *
-	 * @return  Container  Returns itself to support chaining.
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */


### PR DESCRIPTION
Concrete ServiceProvider can **either** return passed Container **or** itself. But itself is not an instance of Container.
The return value is [not being used for anything](https://github.com/joomla/joomla-framework/blob/staging/src/Joomla/DI/Container.php#L424) and usually its just void.
