### PR TITLE
Deprecated Dispatcher::setListenerFilter method.

### DIFF
--- a/src/Joomla/Event/Dispatcher.php
+++ b/src/Joomla/Event/Dispatcher.php
@@ -34,6 +34,7 @@ class Dispatcher implements DispatcherInterface
 	 *
 	 * @var    string
 	 * @since  1.0
+	 * @deprecated
 	 */
 	protected $listenerFilter;
 
@@ -71,7 +72,8 @@ class Dispatcher implements DispatcherInterface
 	 *
 	 * @return  Dispatcher  This method is chainable.
 	 *
-	 * @since   1.0
+	 * @since       1.0
+	 * @deprecated  Incorporate a method in your listener object such as `getEvents` to feed into the `setListener` method.
 	 */
 	public function setListenerFilter($regex)
 	{
@@ -254,12 +256,15 @@ class Dispatcher implements DispatcherInterface
 			$methods = array_intersect($methods, array_keys($events));
 		}
 
+		// @deprecated
 		$regex = $this->listenerFilter ?: '.*';
 
 		foreach ($methods as $event)
 		{
+			// @deprecated - this outer `if` is deprecated.
 			if (preg_match("#$regex#", $event))
 			{
+				// Retain this inner code after removal of the outer `if`.
 				if (!isset($this->listeners[$event]))
 				{
 					$this->listeners[$event] = new ListenersPriorityQueue;

--- a/src/Joomla/Event/README.md
+++ b/src/Joomla/Event/README.md
@@ -109,6 +109,23 @@ $dispatcher = new Dispatcher;
 $dispatcher->addListener(new ContentListener);
 ```
 
+If the object contains other methods that should not be registered, you will need to explicitly list the events to be
+registered. For example:
+
+```php
+$dispatcher->addListener(
+    new ContentListener,
+    array(
+        'onBeforeContentSave' => Priority::NORMAL,
+        'onAfterContentSave' => Priority::NORMAL,
+    )
+);
+
+// Alternatively, include a helper method:
+$listener = new ContentListener;
+$dispatcher->addListener($listener, $listener->getEvents());
+```
+
 ### Registering Closure Listeners
 
 ```php
@@ -136,6 +153,8 @@ $dispatcher->addListener(
 As you noticed, it is possible to specify a listener's priority for a given Event. It is also possible to do so with "object" Listeners.
 
 ### Filtering Listeners
+
+DEPRECATED
 
 Listeners class can become quite complex, and may support public methods other than those required for event handling. The `setListenerFilter` method can be used to set a regular expression that is used to check the method names of objects being added as listeners.
 

--- a/src/Joomla/Event/Tests/DispatcherTest.php
+++ b/src/Joomla/Event/Tests/DispatcherTest.php
@@ -67,6 +67,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @covers  Joomla\Event\Dispatcher::setListenerFilter
 	 * @since   1.0
+	 * @deprecated
 	 */
 	public function testSetListenerFilter()
 	{


### PR DESCRIPTION
I realised that this method was unnecessary and we should be delegating that operation elsewhere and returning the resulting array in the second argument of `setListener`, for example:

``` php
$dispatcher->addListener(
    new ContentListener,
    array(
        'onBeforeContentSave' => Priority::NORMAL,
        'onAfterContentSave' => Priority::NORMAL,
    )
);

// Alternatively, include a helper method:
$listener = new ContentListener;
$dispatcher->addListener($listener, $listener->getEvents());
```
