### PR TITLE
Update AbstractController.php

### DIFF
--- a/src/Joomla/Controller/AbstractController.php
+++ b/src/Joomla/Controller/AbstractController.php
@@ -24,7 +24,7 @@ abstract class AbstractController implements ControllerInterface
 	 * @var    Application\AbstractApplication
 	 * @since  1.0
 	 */
-	private $app;
+	protected $app;
 
 	/**
 	 * The input object.
@@ -32,7 +32,7 @@ abstract class AbstractController implements ControllerInterface
 	 * @var    Input
 	 * @since  1.0
 	 */
-	private $input;
+	protected $input;
 
 	/**
 	 * Instantiate the controller.


### PR DESCRIPTION
If an abstract class is meant to be derived, we should at least provide access to the stuff they need.  Outside, accessor methods are public for general use.
