### PR TITLE
Fix for lowercase support string

### DIFF
--- a/src/Joomla/Form/Field/DatabaseConnection.php
+++ b/src/Joomla/Form/Field/DatabaseConnection.php
@@ -59,7 +59,7 @@ class Field_DatabaseConnection extends Field_List
 
 			foreach ($supported as $support)
 			{
-				if (in_array($support, $available))
+				if (in_array(ucfirst(strtolower($support)), $available))
 				{
 					$options[$support] = Text::_(ucfirst($support));
 				}


### PR DESCRIPTION
Fix issue for work with lowercase string at support attribute in jform field. Example.: support="mysql"
