### PR TITLE
Remove version tag from Filesystem package composer file.

### DIFF
--- a/src/Joomla/Filesystem/composer.json
+++ b/src/Joomla/Filesystem/composer.json
@@ -5,7 +5,6 @@
     "keywords": ["joomla", "framework", "filesystem"],
     "homepage": "https://github.com/joomla/joomla-framework-filesystem",
     "license": "GPL-2.0+",
-    "version": "1.0-beta3",
     "require": {
         "php": ">=5.3.10",
         "joomla/log": "~1.0"


### PR DESCRIPTION
Fixes a problem where if you include any package with Filesystem as a dependency, Composer brings down the entire Framework.
