### PR TITLE
Fix Container::get() for 5.3.10

### DIFF
--- a/src/Joomla/DI/Container.php
+++ b/src/Joomla/DI/Container.php
@@ -347,7 +347,7 @@ class Container
 		{
 			if (!isset($this->instances[$key]) || $forceNew)
 			{
-				$this->instances[$key] = call_user_func_array($raw['callback'], array($this));
+				$this->instances[$key] = call_user_func($raw['callback'], $this);
 			}
 
 			return $this->instances[$key];

--- a/src/Joomla/DI/Container.php
+++ b/src/Joomla/DI/Container.php
@@ -347,7 +347,7 @@ class Container
 		{
 			if (!isset($this->instances[$key]) || $forceNew)
 			{
-				$this->instances[$key] = $raw['callback']($this);
+				$this->instances[$key] = call_user_func_array($raw['callback'], array($this));
 			}
 
 			return $this->instances[$key];


### PR DESCRIPTION
Our Container support callable array, but it will get syntax error when php is 5.3.10 in Ubuntu.

I fix this bug to make this syntax can run in earlier 5.3.x versions:

``` php
$container->set('db', array('Factory', 'getDbo'));
```
