### PR TITLE
Set Input\Cli default filter to "string"

### DIFF
--- a/src/Joomla/Input/Cli.php
+++ b/src/Joomla/Input/Cli.php
@@ -82,6 +82,22 @@ class Cli extends Input
 	}
 
 	/**
+	 * Gets a value from the input data.
+	 *
+	 * @param   string  $name     Name of the value to get.
+	 * @param   mixed   $default  Default value to return if variable does not exist.
+	 * @param   string  $filter   Filter to apply to the value.
+	 *
+	 * @return  mixed  The filtered input value.
+	 *
+	 * @since   1.0
+	 */
+	public function get($name, $default = null, $filter = 'string')
+	{
+		return parent::get($name, $default, $filter);
+	}
+
+	/**
 	 * Method to unserialize the input.
 	 *
 	 * @param   string  $input  The serialized input.

--- a/src/Joomla/Input/Tests/CliTest.php
+++ b/src/Joomla/Input/Tests/CliTest.php
@@ -27,7 +27,7 @@ class CliTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testGet()
 	{
-		$_SERVER['argv'] = array('/dev/null', '--foo=bar', '-ab', 'blah');
+		$_SERVER['argv'] = array('/dev/null', '--foo=bar', '-ab', 'blah', '-g', 'flower sakura');
 		$instance = new Cli(null, array('filter' => new FilterInputMock));
 
 		$this->assertThat(
@@ -52,6 +52,13 @@ class CliTest extends \PHPUnit_Framework_TestCase
 			$instance->args,
 			$this->equalTo(array('blah')),
 			'Line: ' . __LINE__ . '.'
+		);
+
+		// Default filter
+		$this->assertEquals(
+			'flower sakura',
+			$instance->get('g'),
+			'Default filter should be string. Line: ' . __LINE__
 		);
 	}
 


### PR DESCRIPTION
In CLI mode, if we type:

```
cli.php -a "foo bar"
```

The `$input->get('a')` will return `foobar`, but we may hope it be `foo bar`.

I think we can set default filter to `string` instead `cmd` in CLI Input, because I guess that there won't have security issue with input value if someone using CLI to operate system.
