### PR TITLE
Trim \r from CliApplication::in()

### DIFF
--- a/src/Joomla/Application/AbstractCliApplication.php
+++ b/src/Joomla/Application/AbstractCliApplication.php
@@ -102,6 +102,6 @@ abstract class AbstractCliApplication extends AbstractApplication
 	 */
 	public function in()
 	{
-		return rtrim(fread(STDIN, 8192), "\n");
+		return rtrim(fread(STDIN, 8192), "\n\r");
 	}
 }


### PR DESCRIPTION
`AbstractCliApplication::in()` will return value with `\r` in Windows.

I trim it when read value from `STDIN`.
