### PR TITLE
Adds an HTML 5 color picker form field type

### DIFF
--- a/src/Joomla/Application/Cli/Output/Processor/ColorProcessor.php
+++ b/src/Joomla/Application/Cli/Output/Processor/ColorProcessor.php
@@ -53,7 +53,7 @@ class ColorProcessor implements ProcessorInterface
 	/**
 	 * Class constructor
 	 *
-	 * @since  __DEPLOY_VERSION__
+	 * @since  1.1.0
 	 */
 	public function __construct()
 	{

--- a/src/Joomla/Application/Cli/Output/Processor/ProcessorInterface.php
+++ b/src/Joomla/Application/Cli/Output/Processor/ProcessorInterface.php
@@ -11,7 +11,7 @@ namespace Joomla\Application\Cli\Output\Processor;
 /**
  * Class ProcessorInterface.
  *
- * @since  __DEPLOY_VERSION__
+ * @since  1.1.0
  */
 interface ProcessorInterface
 {
@@ -22,7 +22,7 @@ interface ProcessorInterface
 	 *
 	 * @return  string
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since   1.1.0
 	 */
 	public function process($output);
 }

--- a/src/Joomla/Database/Sqlite/SqliteQuery.php
+++ b/src/Joomla/Database/Sqlite/SqliteQuery.php
@@ -132,7 +132,7 @@ class SqliteQuery extends PdoQuery implements PreparableInterface, LimitableInte
 	 *
 	 * @return  string  The required char length call.
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since   1.1.0
 	 */
 	public function charLength($field, $operator = null, $condition = null)
 	{
@@ -171,7 +171,7 @@ class SqliteQuery extends PdoQuery implements PreparableInterface, LimitableInte
 	 *
 	 * @return  string  The concatenated values.
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since   1.1.0
 	 */
 	public function concatenate($values, $separator = null)
 	{

--- a/src/Joomla/Form/Field/Color.php
+++ b/src/Joomla/Form/Field/Color.php
@@ -13,7 +13,7 @@ namespace Joomla\Form;
  * Supports an html colour picker
  *
  * @link   http://www.w3.org/TR/html5/forms.html#color-state-(type=color)
- * @since  1.0
+ * @since  _DEPLOY_VERSION__
  */
 class Field_Color extends Field
 {
@@ -22,7 +22,7 @@ class Field_Color extends Field
 	 *
 	 * @var    string
 	 *
-	 * @since  1.0
+	 * @since  _DEPLOY_VERSION__
 	 */
 	protected $type = 'Color';
 
@@ -31,7 +31,7 @@ class Field_Color extends Field
 	 *
 	 * @return  string  The field input markup.
 	 *
-	 * @since   1.0
+	 * @since   _DEPLOY_VERSION__
 	 */
 	protected function getInput()
 	{

--- a/src/Joomla/Form/Field/Color.php
+++ b/src/Joomla/Form/Field/Color.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Part of the Joomla Framework Form Package
+ *
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Form;
+
+/**
+ * Form Field class for the Joomla Framework.
+ * Supports an html colour picker
+ *
+ * @link   http://www.w3.org/TR/html5/forms.html#color-state-(type=color)
+ * @since  1.0
+ */
+class Field_Color extends Field
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 *
+	 * @since  1.0
+	 */
+	protected $type = 'Color';
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @return  string  The field input markup.
+	 *
+	 * @since   1.0
+	 */
+	protected function getInput()
+	{
+		// Initialize some field attributes.
+		$size = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
+		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
+
+		// Initialize JavaScript field attributes.
+		$onchange = $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
+
+		return '<input type="color" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $class . $size . $disabled . $onchange . '/>';
+	}
+}

--- a/src/Joomla/Form/Tests/fields/JFormFieldColorTest.php
+++ b/src/Joomla/Form/Tests/fields/JFormFieldColorTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Form\Tests;
+
+use Joomla\Test\TestHelper;
+use Joomla\Form\Field_Color;
+
+/**
+ * Test class for JForm.
+ *
+ * @since  _DEPLOY_VERSION__
+ */
+class JFormFieldColorTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * Sets up dependancies for the test.
+	 *
+	 * @return void
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		include_once dirname(__DIR__) . '/inspectors.php';
+	}
+
+	/**
+	 * Test the getInput method.
+	 *
+	 * @return void
+	 */
+	public function testGetInput()
+	{
+		$form = new JFormInspector('form1');
+
+		$this->assertThat(
+			$form->load('<form><field name="color" type="color" /></form>'),
+			$this->isTrue(),
+			'Line:' . __LINE__ . ' XML string should load successfully.'
+		);
+
+		$field = new Field_Color($form);
+
+		$this->assertThat(
+			$field->setup($form->getXml()->field, 'value'),
+			$this->isTrue(),
+			'Line:' . __LINE__ . ' The setup method should return true.'
+		);
+
+		$this->assertThat(
+			strlen($field->input),
+			$this->greaterThan(0),
+			'Line:' . __LINE__ . ' The getInput method should return something without error.'
+		);
+
+	}
+}

--- a/src/Joomla/Github/Package/Repositories/Releases.php
+++ b/src/Joomla/Github/Package/Repositories/Releases.php
@@ -15,7 +15,7 @@ use Joomla\Github\AbstractPackage;
  *
  * @documentation http://developer.github.com/v3/repos/releases
  *
- * @since  __DEPLOY_VERSION__
+ * @since  1.1.0
  */
 class Releases extends AbstractPackage
 {
@@ -37,7 +37,7 @@ class Releases extends AbstractPackage
 	 * @return  object
 	 *
 	 * @link    http://developer.github.com/v3/repos/releases/#create-a-release
-	 * @since   __DEPLOY_VERSION__
+	 * @since   1.1.0
 	 */
 	public function create($user, $repo, $tagName, $targetCommitish = '', $name = '', $body = '', $draft = false, $preRelease = false)
 	{
@@ -79,7 +79,7 @@ class Releases extends AbstractPackage
 	 * @return  object
 	 *
 	 * @link    http://developer.github.com/v3/repos/releases/#edit-a-release
-	 * @since   __DEPLOY_VERSION__
+	 * @since   1.1.0
 	 * @throws  \DomainException
 	 */
 	public function edit($user, $repo, $releaseId, $tagName,
@@ -134,7 +134,7 @@ class Releases extends AbstractPackage
 	 *
 	 * @return  object
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since   1.1.0
 	 * @throws  \DomainException
 	 */
 	public function get($user, $repo, $ref)
@@ -156,7 +156,7 @@ class Releases extends AbstractPackage
 	 *
 	 * @return  array  An associative array of releases keyed by the tag name.
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since   1.1.0
 	 * @throws  \DomainException
 	 */
 	public function getList($user, $repo, $page = 0, $limit = 0)


### PR DESCRIPTION
This PR adds an HTML 5 color picker form field.

This includes the necessary changes as per the spec here:

http://www.w3.org/TR/html5/forms.html#color-state-(type=color)

Includes unit test.

Add this to a form using:

<field name="color" type="color"/>

Cheers,
Eric.

PS: Not sure if I have done this PR correctly.... still trying to get used to using Github for this sort of stuff.
