### PR TITLE
Missed line in coverting $options to array from Registry class

### DIFF
--- a/src/Joomla/Http/Transport/Stream.php
+++ b/src/Joomla/Http/Transport/Stream.php
@@ -123,7 +123,7 @@ class Stream implements TransportInterface
 		$options['ignore_errors'] = 1;
 
 		// Follow redirects.
-		$options['follow_location'] = (int) $this->options->get('follow_location', 1);
+		$options['follow_location'] = (int) (isset($options['follow_location']) ? $options['follow_location'] : 1);
 
 		// Create the stream context for the request.
 		$context = stream_context_create(array('http' => $options));


### PR DESCRIPTION
Getting the following error when making an Oauth2 call using Facebook:

```
Fatal error: Call to a member function get() on a non-object in ... Joomla/Http/Transport/Stream.php on line 126
```

The line seems to be a place where `$options` was not switched to using an array from the old Registry method:

```
$options['follow_location'] = (int) $this->options->get('follow_location', 1);
```

Pull request coming in a bit.
