### PR TITLE
Changing New Image returns to New static to allowing class extending

### DIFF
--- a/src/Joomla/Image/Image.php
+++ b/src/Joomla/Image/Image.php
@@ -411,7 +411,7 @@ class Image implements LoggerAwareInterface
 		if ($createNew)
 		{
 			// @codeCoverageIgnoreStart
-			$new = new Image($handle);
+			$new = new static($handle);
 
 			return $new;
 


### PR DESCRIPTION
If you extend the Image class, and using Crop will return an instance of Image class, and not your extended class
