### PR TITLE
Bug Fix: Session Storage Database

### DIFF
--- a/src/Joomla/Session/Storage/Database.php
+++ b/src/Joomla/Session/Storage/Database.php
@@ -39,6 +39,7 @@ class Database extends Storage
 		if (isset($options['db']) && ($options['db'] instanceof DatabaseDriver))
 		{
 			parent::__construct($options);
+			$this->db = $options['db'];
 		}
 		else
 		{


### PR DESCRIPTION
If I am not completely mistaken, this line is neccessary, because the database object will not be set in the parent class.
