### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,26 +43,10 @@ If you are interested in working with the development code (in the master branch
 
 ### Package Installation Via Composer
 
-There are two ways to add our packages to your existing composer powered application.
-
-##### Adding packages manually to the `require` option in your `composer.json`.
-
-```json
-{
-    "require": {
-        "joomla/PACKAGENAME": "VERSION"
-    }
-}
-```
-and then run install (or update).
-```sh
-php composer.phar install
-```
-
 ##### Adding packages using `composer require`
 
 ```sh
-php composer.phar require joomla/packagename:version
+php composer.phar require joomla/packagename
 ```
 
 ### Full Installation Via Git


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
