### PR TITLE
Add include "additional XML files" functionality

### DIFF
--- a/src/Joomla/Form/Form.php
+++ b/src/Joomla/Form/Form.php
@@ -766,8 +766,8 @@ class Form
 			}
 		}
 
-		// Attempt to load the XML file.
-		$xml = simplexml_load_file($file);
+		// Attempt to load the XML files.
+		$xml = simplexml_load_file($file, 'SimpleXMLElement', LIBXML_NOENT);
 
 		return $this->load($xml, $reset, $xpath);
 	}


### PR DESCRIPTION
[As per reference in tutorial on Custom XML form field types](https://docs.joomla.org/Creating_a_custom_form_field_type)
Adding XML include file functionality
XML form definitions are cumbersome, and maintaining a number of similar forms can be problematic if fieldset and field definitions have only minor differences between forms.

You can alleviate a lot of the drudgery by grouping your fieldset or field definitions in additional files and then include those files in your top level form definition.

This adds a great deal of flexibility and a reduction in developer duplication of effort.
